### PR TITLE
改善 RoInitialize 和 RoUninitialize 的 fallback 实现

### DIFF
--- a/src/Thunks/api-ms-win-core-winrt.hpp
+++ b/src/Thunks/api-ms-win-core-winrt.hpp
@@ -26,7 +26,9 @@ namespace YY
 
 			return CoInitializeEx(
 				nullptr, 
-				COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+				initType == RO_INIT_SINGLETHREADED 
+				? COINIT_APARTMENTTHREADED
+				: COINIT_MULTITHREADED);
 		}
 #endif
 

--- a/src/Thunks/api-ms-win-core-winrt.hpp
+++ b/src/Thunks/api-ms-win-core-winrt.hpp
@@ -24,11 +24,17 @@ namespace YY
 				return pRoInitialize(initType);
 			}
 
-			return CoInitializeEx(
-				nullptr, 
-				initType == RO_INIT_SINGLETHREADED 
-				? COINIT_APARTMENTTHREADED
-				: COINIT_MULTITHREADED);
+			DWORD CoInitializeFlags = COINIT_DISABLE_OLE1DDE;
+			if (initType == RO_INIT_SINGLETHREADED)
+			{
+				CoInitializeFlags |= COINIT_APARTMENTTHREADED;
+			}
+			else
+			{
+				CoInitializeFlags |= COINIT_MULTITHREADED;
+			}
+
+			return CoInitializeEx(nullptr, CoInitializeFlags);
 		}
 #endif
 

--- a/src/Thunks/api-ms-win-core-winrt.hpp
+++ b/src/Thunks/api-ms-win-core-winrt.hpp
@@ -24,7 +24,9 @@ namespace YY
 				return pRoInitialize(initType);
 			}
 
-			return E_NOTIMPL;
+			return CoInitializeEx(
+				nullptr, 
+				COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
 		}
 #endif
 
@@ -44,6 +46,8 @@ namespace YY
 			{
 				return pRoUninitialize();
 			}
+
+			CoUninitialize();
 		}
 #endif
 


### PR DESCRIPTION
刚刚看 YY-Thunks 实现，感觉在 https://github.com/Chuyu-Team/YY-Thunks/blob/master/src/Thunks/api-ms-win-core-winrt.hpp 里面的 RoInitialize 和 RoUninitialize 的逻辑可以继续进行改进

RoInitialize 的 fallback 实现可以直接写成 CoInitializeEx 基本上（Windows 10 以前）是等价实现，同理 RoUninitialize 和 CoUninitialize 也基本上是等价实现

因为我记得 C++/WinRT 这个库可以在 Windows 7 上使用（仅 COM 相关部分）……而且按照 Windows Runtime 的习俗调用 RoInitialize 后就默认不需要进行 COM 初始化……这样可能可以减少一些适配新设施到旧设施的难度

毕竟越来越多的设施会使用 Windows Runtime，按照巨硬越来越多的 API 只提供 Windows Runtime 版本
虽然我们对此无能为力（用 Windows Runtime 接口的部分得重写），但是初始化和反初始化可以 fallback 下以方便一些场景不用写两种实现

毕竟有些要支持 Windows Runtime 上下文的带 callback 的 Win32库应该是需要用 RoInitialize/RoUninitialize 以保证这种情况肯定不会翻车……

附：Windows 10 Build 17763 的 combase.dll 里 RoInitialize 和 RoUninitialize 的实现的伪代码截图
![image](https://user-images.githubusercontent.com/10867563/123574299-2c516c80-d802-11eb-8098-e928d0cedc68.png)
![image](https://user-images.githubusercontent.com/10867563/123574312-31aeb700-d802-11eb-99b4-8d74b5614787.png)

毛利