### PR TITLE
更新 Locale API 使用的表格 (依照 Win 11 23H2 环境下 API 调用的结果)

### DIFF
--- a/src/Thunks/api-ms-win-core-localization.hpp
+++ b/src/Thunks/api-ms-win-core-localization.hpp
@@ -80,248 +80,317 @@ namespace YY
 				static constexpr LcidFallback FallbackTable[] =
 				{
 					{ 0x00000004, 0x00007804 }, //zh-Hans -> zh
-					{ 0x00000401, 0x00000001 }, //ar-SA -> ar 
-					{ 0x00000402, 0x00000002 }, //bg-BG -> bg 
-					{ 0x00000403, 0x00000003 }, //ca-ES -> ca 
-					{ 0x00000404, 0x00007C04 }, //zh-TW -> zh-Hant 
-					{ 0x00000405, 0x00000005 }, //cs-CZ -> cs 
-					{ 0x00000406, 0x00000006 }, //da-DK -> da 
-					{ 0x00000407, 0x00000007 }, //de-DE -> de 
-					{ 0x00000408, 0x00000008 }, //el-GR -> el 
-					{ 0x00000409, 0x00000009 }, //en-US -> en 
-					{ 0x0000040A, 0x0000000A }, //es-ES_tradnl -> es 
-					{ 0x0000040B, 0x0000000B }, //fi-FI -> fi 
-					{ 0x0000040C, 0x0000000C }, //fr-FR -> fr 
-					{ 0x0000040D, 0x0000000D }, //he-IL -> he 
-					{ 0x0000040E, 0x0000000E }, //hu-HU -> hu 
-					{ 0x0000040F, 0x0000000F }, //is-IS -> is 
-					{ 0x00000410, 0x00000010 }, //it-IT -> it 
-					{ 0x00000411, 0x00000011 }, //ja-JP -> ja 
-					{ 0x00000412, 0x00000012 }, //ko-KR -> ko 
-					{ 0x00000413, 0x00000013 }, //nl-NL -> nl 
-					{ 0x00000414, 0x00007C14 }, //nb-NO -> nb 
-					{ 0x00000415, 0x00000015 }, //pl-PL -> pl 
-					{ 0x00000416, 0x00000016 }, //pt-BR -> pt 
-					{ 0x00000417, 0x00000017 }, //rm-CH -> rm 
-					{ 0x00000418, 0x00000018 }, //ro-RO -> ro 
-					{ 0x00000419, 0x00000019 }, //ru-RU -> ru 
-					{ 0x0000041A, 0x0000001A }, //hr-HR -> hr 
-					{ 0x0000041B, 0x0000001B }, //sk-SK -> sk 
-					{ 0x0000041C, 0x0000001C }, //sq-AL -> sq 
-					{ 0x0000041D, 0x0000001D }, //sv-SE -> sv 
-					{ 0x0000041E, 0x0000001E }, //th-TH -> th 
-					{ 0x0000041F, 0x0000001F }, //tr-TR -> tr 
-					{ 0x00000420, 0x00000020 }, //ur-PK -> ur 
-					{ 0x00000421, 0x00000021 }, //id-ID -> id 
-					{ 0x00000422, 0x00000022 }, //uk-UA -> uk 
-					{ 0x00000423, 0x00000023 }, //be-BY -> be 
-					{ 0x00000424, 0x00000024 }, //sl-SI -> sl 
-					{ 0x00000425, 0x00000025 }, //et-EE -> et 
-					{ 0x00000426, 0x00000026 }, //lv-LV -> lv 
-					{ 0x00000427, 0x00000027 }, //lt-LT -> lt 
+					{ 0x00000401, 0x00000001 }, //ar-SA -> ar
+					{ 0x00000402, 0x00000002 }, //bg-BG -> bg
+					{ 0x00000403, 0x00000003 }, //ca-ES -> ca
+					{ 0x00000404, 0x00007C04 }, //zh-TW -> zh-Hant
+					{ 0x00000405, 0x00000005 }, //cs-CZ -> cs
+					{ 0x00000406, 0x00000006 }, //da-DK -> da
+					{ 0x00000407, 0x00000007 }, //de-DE -> de
+					{ 0x00000408, 0x00000008 }, //el-GR -> el
+					{ 0x00000409, 0x00000009 }, //en-US -> en
+					{ 0x0000040A, 0x0000000A }, //es-ES_tradnl -> es
+					{ 0x0000040B, 0x0000000B }, //fi-FI -> fi
+					{ 0x0000040C, 0x0000000C }, //fr-FR -> fr
+					{ 0x0000040D, 0x0000000D }, //he-IL -> he
+					{ 0x0000040E, 0x0000000E }, //hu-HU -> hu
+					{ 0x0000040F, 0x0000000F }, //is-IS -> is
+					{ 0x00000410, 0x00000010 }, //it-IT -> it
+					{ 0x00000411, 0x00000011 }, //ja-JP -> ja
+					{ 0x00000412, 0x00000012 }, //ko-KR -> ko
+					{ 0x00000413, 0x00000013 }, //nl-NL -> nl
+					{ 0x00000414, 0x00007C14 }, //nb-NO -> nb
+					{ 0x00000415, 0x00000015 }, //pl-PL -> pl
+					{ 0x00000416, 0x00000016 }, //pt-BR -> pt
+					{ 0x00000417, 0x00000017 }, //rm-CH -> rm
+					{ 0x00000418, 0x00000018 }, //ro-RO -> ro
+					{ 0x00000419, 0x00000019 }, //ru-RU -> ru
+					{ 0x0000041A, 0x0000001A }, //hr-HR -> hr
+					{ 0x0000041B, 0x0000001B }, //sk-SK -> sk
+					{ 0x0000041C, 0x0000001C }, //sq-AL -> sq
+					{ 0x0000041D, 0x0000001D }, //sv-SE -> sv
+					{ 0x0000041E, 0x0000001E }, //th-TH -> th
+					{ 0x0000041F, 0x0000001F }, //tr-TR -> tr
+					{ 0x00000420, 0x00000020 }, //ur-PK -> ur
+					{ 0x00000421, 0x00000021 }, //id-ID -> id
+					{ 0x00000422, 0x00000022 }, //uk-UA -> uk
+					{ 0x00000423, 0x00000023 }, //be-BY -> be
+					{ 0x00000424, 0x00000024 }, //sl-SI -> sl
+					{ 0x00000425, 0x00000025 }, //et-EE -> et
+					{ 0x00000426, 0x00000026 }, //lv-LV -> lv
+					{ 0x00000427, 0x00000027 }, //lt-LT -> lt
 					{ 0x00000428, 0x00007C28 }, //tg-Cyrl-TJ -> tg-Cyrl
-					{ 0x00000429, 0x00000029 }, //fa-IR -> fa 
-					{ 0x0000042A, 0x0000002A }, //vi-VN -> vi 
-					{ 0x0000042B, 0x0000002B }, //hy-AM -> hy 
+					{ 0x00000429, 0x00000029 }, //fa-IR -> fa
+					{ 0x0000042A, 0x0000002A }, //vi-VN -> vi
+					{ 0x0000042B, 0x0000002B }, //hy-AM -> hy
 					{ 0x0000042C, 0x0000782C }, //az-Latn-AZ -> az-Latn
-					{ 0x0000042D, 0x0000002D }, //eu-ES -> eu 
-					{ 0x0000042E, 0x0000002E }, //hsb-DE -> hsb 
-					{ 0x0000042F, 0x0000002F }, //mk-MK -> mk 
-					{ 0x00000432, 0x00000032 }, //tn-ZA -> tn 
-					{ 0x00000434, 0x00000034 }, //xh-ZA -> xh 
-					{ 0x00000435, 0x00000035 }, //zu-ZA -> zu 
-					{ 0x00000436, 0x00000036 }, //af-ZA -> af 
-					{ 0x00000437, 0x00000037 }, //ka-GE -> ka 
-					{ 0x00000438, 0x00000038 }, //fo-FO -> fo 
-					{ 0x00000439, 0x00000039 }, //hi-IN -> hi 
-					{ 0x0000043A, 0x0000003A }, //mt-MT -> mt 
-					{ 0x0000043B, 0x0000003B }, //se-NO -> se 
-					{ 0x0000043E, 0x0000003E }, //ms-MY -> ms 
-					{ 0x0000043F, 0x0000003F }, //kk-KZ -> kk 
-					{ 0x00000440, 0x00000040 }, //ky-KG -> ky 
-					{ 0x00000441, 0x00000041 }, //sw-KE -> sw 
-					{ 0x00000442, 0x00000042 }, //tk-TM -> tk 
+					{ 0x0000042D, 0x0000002D }, //eu-ES -> eu
+					{ 0x0000042E, 0x0000002E }, //hsb-DE -> hsb
+					{ 0x0000042F, 0x0000002F }, //mk-MK -> mk
+					{ 0x00000430, 0x00000030 }, //st-ZA -> st
+					{ 0x00000431, 0x00000031 }, //ts-ZA -> ts
+					{ 0x00000432, 0x00000032 }, //tn-ZA -> tn
+					{ 0x00000433, 0x00000033 }, //ve-ZA -> ve
+					{ 0x00000434, 0x00000034 }, //xh-ZA -> xh
+					{ 0x00000435, 0x00000035 }, //zu-ZA -> zu
+					{ 0x00000436, 0x00000036 }, //af-ZA -> af
+					{ 0x00000437, 0x00000037 }, //ka-GE -> ka
+					{ 0x00000438, 0x00000038 }, //fo-FO -> fo
+					{ 0x00000439, 0x00000039 }, //hi-IN -> hi
+					{ 0x0000043A, 0x0000003A }, //mt-MT -> mt
+					{ 0x0000043B, 0x0000003B }, //se-NO -> se
+					{ 0x0000043D, 0x0000003D }, //yi-001 -> yi
+					{ 0x0000043E, 0x0000003E }, //ms-MY -> ms
+					{ 0x0000043F, 0x0000003F }, //kk-KZ -> kk
+					{ 0x00000440, 0x00000040 }, //ky-KG -> ky
+					{ 0x00000441, 0x00000041 }, //sw-KE -> sw
+					{ 0x00000442, 0x00000042 }, //tk-TM -> tk
 					{ 0x00000443, 0x00007C43 }, //uz-Latn-UZ -> uz-Latn
-					{ 0x00000444, 0x00000044 }, //tt-RU -> tt 
-					{ 0x00000445, 0x00000045 }, //bn-IN -> bn 
+					{ 0x00000444, 0x00000044 }, //tt-RU -> tt
+					{ 0x00000445, 0x00000045 }, //bn-IN -> bn
 					{ 0x00000446, 0x00000046 }, //pa-IN -> pa 
-					{ 0x00000447, 0x00000047 }, //gu-IN -> gu 
-					{ 0x00000448, 0x00000048 }, //or-IN -> or 
-					{ 0x00000449, 0x00000049 }, //ta-IN -> ta 
-					{ 0x0000044A, 0x0000004A }, //te-IN -> te 
-					{ 0x0000044B, 0x0000004B }, //kn-IN -> kn 
-					{ 0x0000044C, 0x0000004C }, //ml-IN -> ml 
-					{ 0x0000044D, 0x0000004D }, //as-IN -> as 
-					{ 0x0000044E, 0x0000004E }, //mr-IN -> mr 
-					{ 0x0000044F, 0x0000004F }, //sa-IN -> sa 
+					{ 0x00000447, 0x00000047 }, //gu-IN -> gu
+					{ 0x00000448, 0x00000048 }, //or-IN -> or
+					{ 0x00000449, 0x00000049 }, //ta-IN -> ta
+					{ 0x0000044A, 0x0000004A }, //te-IN -> te
+					{ 0x0000044B, 0x0000004B }, //kn-IN -> kn
+					{ 0x0000044C, 0x0000004C }, //ml-IN -> ml
+					{ 0x0000044D, 0x0000004D }, //as-IN -> as
+					{ 0x0000044E, 0x0000004E }, //mr-IN -> mr
+					{ 0x0000044F, 0x0000004F }, //sa-IN -> sa
 					{ 0x00000450, 0x00007850 }, //mn-MN -> mn-Cyrl
-					{ 0x00000451, 0x00000051 }, //bo-CN -> bo 
-					{ 0x00000452, 0x00000052 }, //cy-GB -> cy 
-					{ 0x00000453, 0x00000053 }, //km-KH -> km 
-					{ 0x00000454, 0x00000054 }, //lo-LA -> lo 
-					{ 0x00000456, 0x00000056 }, //gl-ES -> gl 
-					{ 0x00000457, 0x00000057 }, //kok-IN -> kok 
-					{ 0x0000045A, 0x0000005A }, //syr-SY -> syr 
-					{ 0x0000045B, 0x0000005B }, //si-LK -> si 
+					{ 0x00000451, 0x00000051 }, //bo-CN -> bo
+					{ 0x00000452, 0x00000052 }, //cy-GB -> cy
+					{ 0x00000453, 0x00000053 }, //km-KH -> km
+					{ 0x00000454, 0x00000054 }, //lo-LA -> lo
+					{ 0x00000455, 0x00000055 }, //my-MM -> my
+					{ 0x00000456, 0x00000056 }, //gl-ES -> gl
+					{ 0x00000457, 0x00000057 }, //kok-IN -> kok
+					{ 0x00000458, 0x00001000 }, //mni-IN -> mni-Beng
+					{ 0x00000459, 0x00001000 }, //sd-Deva-IN -> sd-Deva
+					{ 0x0000045A, 0x0000005A }, //syr-SY -> syr
+					{ 0x0000045B, 0x0000005B }, //si-LK -> si
+					{ 0x0000045C, 0x00007C5C }, //chr-Cher-US -> chr-Cher
 					{ 0x0000045D, 0x0000785D }, //iu-Cans-CA -> iu-Cans
-					{ 0x0000045E, 0x0000005E }, //am-ET -> am 
-					{ 0x00000461, 0x00000061 }, //ne-NP -> ne 
-					{ 0x00000462, 0x00000062 }, //fy-NL -> fy 
-					{ 0x00000463, 0x00000063 }, //ps-AF -> ps 
-					{ 0x00000464, 0x00000064 }, //fil-PH -> fil 
-					{ 0x00000465, 0x00000065 }, //dv-MV -> dv 
+					{ 0x0000045E, 0x0000005E }, //am-ET -> am
+					{ 0x0000045F, 0x00001000 }, //tzm-Arab-MA -> tzm-Arab
+					{ 0x00000460, 0x00000060 }, //ks-Arab -> ks
+					{ 0x00000461, 0x00000061 }, //ne-NP -> ne
+					{ 0x00000462, 0x00000062 }, //fy-NL -> fy
+					{ 0x00000463, 0x00000063 }, //ps-AF -> ps
+					{ 0x00000464, 0x00000064 }, //fil-PH -> fil
+					{ 0x00000465, 0x00000065 }, //dv-MV -> dv
+					{ 0x00000466, 0x00000066 }, //bin-NG -> bin
+					{ 0x00000467, 0x00007C67 }, //ff-Latn-NG -> ff-Latn
 					{ 0x00000468, 0x00007C68 }, //ha-Latn-NG -> ha-Latn
-					{ 0x0000046A, 0x0000006A }, //yo-NG -> yo 
-					{ 0x0000046B, 0x0000006B }, //quz-BO -> quz 
-					{ 0x0000046C, 0x0000006C }, //nso-ZA -> nso 
-					{ 0x0000046D, 0x0000006D }, //ba-RU -> ba 
-					{ 0x0000046E, 0x0000006E }, //lb-LU -> lb 
-					{ 0x0000046F, 0x0000006F }, //kl-GL -> kl 
-					{ 0x00000470, 0x00000070 }, //ig-NG -> ig 
-					{ 0x00000478, 0x00000078 }, //ii-CN -> ii 
-					{ 0x0000047A, 0x0000007A }, //arn-CL -> arn 
-					{ 0x0000047C, 0x0000007C }, //moh-CA -> moh 
-					{ 0x0000047E, 0x0000007E }, //br-FR -> br 
-					{ 0x00000480, 0x00000080 }, //ug-CN -> ug 
-					{ 0x00000481, 0x00000081 }, //mi-NZ -> mi 
-					{ 0x00000482, 0x00000082 }, //oc-FR -> oc 
-					{ 0x00000483, 0x00000083 }, //co-FR -> co 
-					{ 0x00000484, 0x00000084 }, //gsw-FR -> gsw 
-					{ 0x00000485, 0x00000085 }, //sah-RU -> sah 
+					{ 0x00000469, 0x00000069 }, //ibb-NG -> ibb
+					{ 0x0000046A, 0x0000006A }, //yo-NG -> yo
+					{ 0x0000046B, 0x0000006B }, //quz-BO -> quz
+					{ 0x0000046C, 0x0000006C }, //nso-ZA -> nso
+					{ 0x0000046D, 0x0000006D }, //ba-RU -> ba
+					{ 0x0000046E, 0x0000006E }, //lb-LU -> lb
+					{ 0x0000046F, 0x0000006F }, //kl-GL -> kl
+					{ 0x00000470, 0x00000070 }, //ig-NG -> ig
+					{ 0x00000471, 0x00001000 }, //kr-Latn-NG -> kr-Latn
+					{ 0x00000472, 0x00000072 }, //om-ET -> om
+					{ 0x00000473, 0x00000073 }, //ti-ET -> ti
+					{ 0x00000474, 0x00000074 }, //gn-PY -> gn
+					{ 0x00000475, 0x00000075 }, //haw-US -> haw
+					{ 0x00000476, 0x00000076 }, //la-VA -> la
+					{ 0x00000477, 0x00000077 }, //so-SO -> so
+					{ 0x00000478, 0x00000078 }, //ii-CN -> ii
+					{ 0x00000479, 0x00000079 }, //pap-029 -> pap
+					{ 0x0000047A, 0x0000007A }, //arn-CL -> arn
+					{ 0x0000047C, 0x0000007C }, //moh-CA -> moh
+					{ 0x0000047E, 0x0000007E }, //br-FR -> br
+					{ 0x00000480, 0x00000080 }, //ug-CN -> ug
+					{ 0x00000481, 0x00000081 }, //mi-NZ -> mi
+					{ 0x00000482, 0x00000082 }, //oc-FR -> oc
+					{ 0x00000483, 0x00000083 }, //co-FR -> co
+					{ 0x00000484, 0x00000084 }, //gsw-FR -> gsw
+					{ 0x00000485, 0x00000085 }, //sah-RU -> sah
 					{ 0x00000486, 0x00000086 }, //qut-GT -> qut 
-					{ 0x00000487, 0x00000087 }, //rw-RW -> rw 
-					{ 0x00000488, 0x00000088 }, //wo-SN -> wo 
-					{ 0x0000048C, 0x0000008C }, //prs-AF -> prs 
-					{ 0x00000491, 0x00000091 }, //gd-GB -> gd 
-					{ 0x00000501, 0x00000009 }, //qps-ploc -> en 
-					{ 0x000005FE, 0x00000011 }, //qps-ploca -> ja 
-					{ 0x00000801, 0x00000001 }, //ar-IQ -> ar 
-					{ 0x00000804, 0x00000004 }, //zh-CN -> zh-Hans 
-					{ 0x00000807, 0x00000007 }, //de-CH -> de 
-					{ 0x00000809, 0x00000009 }, //en-GB -> en 
-					{ 0x0000080A, 0x0000000A }, //es-MX -> es 
-					{ 0x0000080C, 0x0000000C }, //fr-BE -> fr 
-					{ 0x00000810, 0x00000010 }, //it-CH -> it 
-					{ 0x00000813, 0x00000013 }, //nl-BE -> nl 
-					{ 0x00000814, 0x00007814 }, //nn-NO -> nn 
-					{ 0x00000816, 0x00000016 }, //pt-PT -> pt 
-					{ 0x0000081A, 0x0000701A }, //sr-Latn-CS -> sr-Latn 
-					{ 0x0000081D, 0x0000001D }, //sv-FI -> sv 
-					{ 0x0000082C, 0x0000742C }, //az-Cyrl-AZ -> az-Cyrl 
-					{ 0x0000082E, 0x00007C2E }, //dsb-DE -> dsb 
-					{ 0x0000083B, 0x0000003B }, //se-SE -> se 
-					{ 0x0000083C, 0x0000003C }, //ga-IE -> ga 
-					{ 0x0000083E, 0x0000003E }, //ms-BN -> ms 
+					{ 0x00000487, 0x00000087 }, //rw-RW -> rw
+					{ 0x00000488, 0x00000088 }, //wo-SN -> wo
+					{ 0x0000048C, 0x00000029 }, //fa-AF -> fa
+					{ 0x00000491, 0x00000091 }, //gd-GB -> gd
+					{ 0x00000492, 0x00007C92 }, //ku-Arab-IQ -> ku-Arab
+					{ 0x00000501, 0x00000009 }, //qps-ploc -> en
+					{ 0x000005FE, 0x00000011 }, //qps-ploca -> ja
+					{ 0x00000801, 0x00000001 }, //ar-IQ -> ar
+					{ 0x00000803, 0x00000403 }, //ca-ES-valencia -> ca-ES
+					{ 0x00000804, 0x00000004 }, //zh-CN -> zh-Hans
+					{ 0x00000807, 0x00000007 }, //de-CH -> de
+					{ 0x00000809, 0x00000009 }, //en-GB -> en
+					{ 0x0000080A, 0x0000000A }, //es-MX -> es
+					{ 0x0000080C, 0x0000000C }, //fr-BE -> fr
+					{ 0x00000810, 0x00000010 }, //it-CH -> it
+					{ 0x00000813, 0x00000013 }, //nl-BE -> nl
+					{ 0x00000814, 0x00007814 }, //nn-NO -> nn
+					{ 0x00000816, 0x00000016 }, //pt-PT -> pt
+					{ 0x00000818, 0x00000018 }, //ro-MD -> ro
+					{ 0x00000819, 0x00000019 }, //ru-MD -> ru
+					{ 0x0000081A, 0x0000701A }, //sr-Latn-CS -> sr-Latn
+					{ 0x0000081D, 0x0000001D }, //sv-FI -> sv
+					{ 0x00000820, 0x00000020 }, //ur-IN -> ur
+					{ 0x0000082C, 0x0000742C }, //az-Cyrl-AZ -> az-Cyrl
+					{ 0x0000082E, 0x00007C2E }, //dsb-DE -> dsb
+					{ 0x00000832, 0x00000032 }, //tn-BW -> tn
+					{ 0x0000083B, 0x0000003B }, //se-SE -> se
+					{ 0x0000083C, 0x0000003C }, //ga-IE -> ga
+					{ 0x0000083E, 0x0000003E }, //ms-BN -> ms
 					{ 0x00000843, 0x00007843 }, //uz-Cyrl-UZ -> uz-Cyrl
-					{ 0x00000845, 0x00000045 }, //bn-BD -> bn 
+					{ 0x00000845, 0x00000045 }, //bn-BD -> bn
+					{ 0x00000846, 0x00007C46 }, //pa-Arab-PK -> pa-Arab
+					{ 0x00000849, 0x00000049 }, //ta-LK -> ta
 					{ 0x00000850, 0x00007C50 }, //mn-Mong-CN -> mn-Mong
+					{ 0x00000859, 0x00007C59 }, //sd-Arab-PK -> sd-Arab
 					{ 0x0000085D, 0x00007C5D }, //iu-Latn-CA -> iu-Latn
 					{ 0x0000085F, 0x00007C5F }, //tzm-Latn-DZ -> tzm-Latn
-					{ 0x0000086B, 0x0000006B }, //quz-EC -> quz 
-					{ 0x000009FF, 0x00000001 }, //qps-plocm -> ar 
-					{ 0x00000C01, 0x00000001 }, //ar-EG -> ar 
-					{ 0x00000C04, 0x00007C04 }, //zh-HK -> zh-Hant 
-					{ 0x00000C07, 0x00000007 }, //de-AT -> de 
-					{ 0x00000C09, 0x00000009 }, //en-AU -> en 
-					{ 0x00000C0A, 0x0000000A }, //es-ES -> es 
-					{ 0x00000C0C, 0x0000000C }, //fr-CA -> fr 
+					{ 0x00000860, 0x00001000 }, //ks-Deva-IN -> ks-Deva
+					{ 0x00000861, 0x00000061 }, //ne-IN -> ne
+					{ 0x00000867, 0x00007C67 }, //ff-Latn-SN -> ff-Latn
+					{ 0x0000086B, 0x0000006B }, //quz-EC -> quz
+					{ 0x00000873, 0x00000073 }, //ti-ER -> ti
+					{ 0x00000901, 0x00000009 }, //qps-Latn-x-sh -> en
+					{ 0x000009FF, 0x00000001 }, //qps-plocm -> ar
+					{ 0x00000C01, 0x00000001 }, //ar-EG -> ar
+					{ 0x00000C04, 0x00007C04 }, //zh-HK -> zh-Hant
+					{ 0x00000C07, 0x00000007 }, //de-AT -> de
+					{ 0x00000C09, 0x00000009 }, //en-AU -> en
+					{ 0x00000C0A, 0x0000000A }, //es-ES -> es
+					{ 0x00000C0C, 0x0000000C }, //fr-CA -> fr
 					{ 0x00000C1A, 0x00006C1A }, //sr-Cyrl-CS -> sr-Cyrl
-					{ 0x00000C3B, 0x0000003B }, //se-FI -> se 
-					{ 0x00000C6B, 0x0000006B }, //quz-PE -> quz 
-					{ 0x00001001, 0x00000001 }, //ar-LY -> ar 
-					{ 0x00001004, 0x00000004 }, //zh-SG -> zh-Hans 
-					{ 0x00001007, 0x00000007 }, //de-LU -> de 
-					{ 0x00001009, 0x00000009 }, //en-CA -> en 
-					{ 0x0000100A, 0x0000000A }, //es-GT -> es 
-					{ 0x0000100C, 0x0000000C }, //fr-CH -> fr 
-					{ 0x0000101A, 0x0000001A }, //hr-BA -> hr 
-					{ 0x0000103B, 0x00007C3B }, //smj-NO -> smj 
-					{ 0x00001401, 0x00000001 }, //ar-DZ -> ar 
-					{ 0x00001404, 0x00007C04 }, //zh-MO -> zh-Hant 
-					{ 0x00001407, 0x00000007 }, //de-LI -> de 
-					{ 0x00001409, 0x00000009 }, //en-NZ -> en 
-					{ 0x0000140A, 0x0000000A }, //es-CR -> es 
-					{ 0x0000140C, 0x0000000C }, //fr-LU -> fr 
+					{ 0x00000C3B, 0x0000003B }, //se-FI -> se
+					{ 0x00000C50, 0x00007C50 }, //mn-Mong-MN -> mn-Mong
+					{ 0x00000C51, 0x00001000 }, //dz-BT -> dz
+					{ 0x00000C6B, 0x0000006B }, //quz-PE -> quz
+					{ 0x00001000, 0x00000460 }, //ks-Arab-IN -> ks-Arab
+					{ 0x00001001, 0x00000001 }, //ar-LY -> ar
+					{ 0x00001004, 0x00000004 }, //zh-SG -> zh-Hans
+					{ 0x00001007, 0x00000007 }, //de-LU -> de
+					{ 0x00001009, 0x00000009 }, //en-CA -> en
+					{ 0x0000100A, 0x0000000A }, //es-GT -> es
+					{ 0x0000100C, 0x0000000C }, //fr-CH -> fr
+					{ 0x0000101A, 0x0000001A }, //hr-BA -> hr
+					{ 0x0000103B, 0x00007C3B }, //smj-NO -> smj
+					{ 0x0000105F, 0x0000785F }, //tzm-Tfng-MA -> tzm-Tfng
+					{ 0x00001401, 0x00000001 }, //ar-DZ -> ar
+					{ 0x00001404, 0x00007C04 }, //zh-MO -> zh-Hant
+					{ 0x00001407, 0x00000007 }, //de-LI -> de
+					{ 0x00001409, 0x00000009 }, //en-NZ -> en
+					{ 0x0000140A, 0x0000000A }, //es-CR -> es
+					{ 0x0000140C, 0x0000000C }, //fr-LU -> fr
 					{ 0x0000141A, 0x0000681A }, //bs-Latn-BA -> bs-Latn
-					{ 0x0000143B, 0x00007C3B }, //smj-SE -> smj 
-					{ 0x00001801, 0x00000001 }, //ar-MA -> ar 
-					{ 0x00001809, 0x00000009 }, //en-IE -> en 
-					{ 0x0000180A, 0x0000000A }, //es-PA -> es 
-					{ 0x0000180C, 0x0000000C }, //fr-MC -> fr 
+					{ 0x0000143B, 0x00007C3B }, //smj-SE -> smj
+					{ 0x00001801, 0x00000001 }, //ar-MA -> ar
+					{ 0x00001809, 0x00000009 }, //en-IE -> en
+					{ 0x0000180A, 0x0000000A }, //es-PA -> es
+					{ 0x0000180C, 0x0000000C }, //fr-MC -> fr
 					{ 0x0000181A, 0x0000701A }, //sr-Latn-BA -> sr-Latn
-					{ 0x0000183B, 0x0000783B }, //sma-NO -> sma 
-					{ 0x00001C01, 0x00000001 }, //ar-TN -> ar 
-					{ 0x00001C09, 0x00000009 }, //en-ZA -> en 
-					{ 0x00001C0A, 0x0000000A }, //es-DO -> es 
+					{ 0x0000183B, 0x0000783B }, //sma-NO -> sma
+					{ 0x00001C01, 0x00000001 }, //ar-TN -> ar
+					{ 0x00001C09, 0x00000009 }, //en-ZA -> en
+					{ 0x00001C0A, 0x0000000A }, //es-DO -> es
+					{ 0x00001C0C, 0x0000000C }, //fr-029 -> fr
 					{ 0x00001C1A, 0x00006C1A }, //sr-Cyrl-BA -> sr-Cyrl
-					{ 0x00001C3B, 0x0000783B }, //sma-SE -> sma 
-					{ 0x00002001, 0x00000001 }, //ar-OM -> ar 
-					{ 0x00002009, 0x00000009 }, //en-JM -> en 
-					{ 0x0000200A, 0x0000000A }, //es-VE -> es 
+					{ 0x00001C3B, 0x0000783B }, //sma-SE -> sma
+					{ 0x00002001, 0x00000001 }, //ar-OM -> ar
+					{ 0x00002009, 0x00000009 }, //en-JM -> en
+					{ 0x0000200A, 0x0000000A }, //es-VE -> es
+					{ 0x0000200C, 0x0000000C }, //fr-RE -> fr
 					{ 0x0000201A, 0x0000641A }, //bs-Cyrl-BA -> bs-Cyrl
-					{ 0x0000203B, 0x0000743B }, //sms-FI -> sms 
-					{ 0x00002401, 0x00000001 }, //ar-YE -> ar 
-					{ 0x00002409, 0x00000009 }, //en-029 -> en 
-					{ 0x0000240A, 0x0000000A }, //es-CO -> es 
+					{ 0x0000203B, 0x0000743B }, //sms-FI -> sms
+					{ 0x00002401, 0x00000001 }, //ar-YE -> ar
+					{ 0x00002409, 0x00000009 }, //en-029 -> en
+					{ 0x0000240A, 0x0000000A }, //es-CO -> es
+					{ 0x0000240C, 0x0000000C }, //fr-CD -> fr
 					{ 0x0000241A, 0x0000701A }, //sr-Latn-RS -> sr-Latn
-					{ 0x0000243B, 0x0000703B }, //smn-FI -> smn 
-					{ 0x00002801, 0x00000001 }, //ar-SY -> ar 
-					{ 0x00002809, 0x00000009 }, //en-BZ -> en 
-					{ 0x0000280A, 0x0000000A }, //es-PE -> es 
+					{ 0x0000243B, 0x0000703B }, //smn-FI -> smn
+					{ 0x00002801, 0x00000001 }, //ar-SY -> ar
+					{ 0x00002809, 0x00000009 }, //en-BZ -> en
+					{ 0x0000280A, 0x0000000A }, //es-PE -> es
+					{ 0x0000280C, 0x0000000C }, //fr-SN -> fr
 					{ 0x0000281A, 0x00006C1A }, //sr-Cyrl-RS -> sr-Cyrl
-					{ 0x00002C01, 0x00000001 }, //ar-JO -> ar 
-					{ 0x00002C09, 0x00000009 }, //en-TT -> en 
-					{ 0x00002C0A, 0x0000000A }, //es-AR -> es 
+					{ 0x00002C01, 0x00000001 }, //ar-JO -> ar
+					{ 0x00002C09, 0x00000009 }, //en-TT -> en
+					{ 0x00002C0A, 0x0000000A }, //es-AR -> es
+					{ 0x00002C0C, 0x0000000C }, //fr-CM -> fr
 					{ 0x00002C1A, 0x0000701A }, //sr-Latn-ME -> sr-Latn
-					{ 0x00003001, 0x00000001 }, //ar-LB -> ar 
-					{ 0x00003009, 0x00000009 }, //en-ZW -> en 
-					{ 0x0000300A, 0x0000000A }, //es-EC -> es 
+					{ 0x00003001, 0x00000001 }, //ar-LB -> ar
+					{ 0x00003009, 0x00000009 }, //en-ZW -> en
+					{ 0x0000300A, 0x0000000A }, //es-EC -> es
+					{ 0x0000300C, 0x0000000C }, //fr-CI -> fr
 					{ 0x0000301A, 0x00006C1A }, //sr-Cyrl-ME -> sr-Cyrl
-					{ 0x00003401, 0x00000001 }, //ar-KW -> ar 
-					{ 0x00003409, 0x00000009 }, //en-PH -> en 
-					{ 0x0000340A, 0x0000000A }, //es-CL -> es 
-					{ 0x00003801, 0x00000001 }, //ar-AE -> ar 
-					{ 0x0000380A, 0x0000000A }, //es-UY -> es 
-					{ 0x00003C01, 0x00000001 }, //ar-BH -> ar 
-					{ 0x00003C0A, 0x0000000A }, //es-PY -> es 
-					{ 0x00004001, 0x00000001 }, //ar-QA -> ar 
-					{ 0x00004009, 0x00000009 }, //en-IN -> en 
-					{ 0x0000400A, 0x0000000A }, //es-BO -> es 
-					{ 0x00004409, 0x00000009 }, //en-MY -> en 
-					{ 0x0000440A, 0x0000000A }, //es-SV -> es 
-					{ 0x00004809, 0x00000009 }, //en-SG -> en 
-					{ 0x0000480A, 0x0000000A }, //es-HN -> es 
-					{ 0x00004C0A, 0x0000000A }, //es-NI -> es 
-					{ 0x0000500A, 0x0000000A }, //es-PR -> es 
-					{ 0x0000540A, 0x0000000A }, //es-US -> es 
+					{ 0x00003401, 0x00000001 }, //ar-KW -> ar
+					{ 0x00003409, 0x00000009 }, //en-PH -> en
+					{ 0x0000340A, 0x0000000A }, //es-CL -> es
+					{ 0x0000340C, 0x0000000C }, //fr-ML -> fr
+					{ 0x00003801, 0x00000001 }, //ar-AE -> ar
+					{ 0x00003809, 0x00000009 }, //en-ID -> en
+					{ 0x0000380A, 0x0000000A }, //es-UY -> es
+					{ 0x0000380C, 0x0000000C }, //fr-MA -> fr
+					{ 0x00003C01, 0x00000001 }, //ar-BH -> ar
+					{ 0x00003C09, 0x00000009 }, //en-HK -> en
+					{ 0x00003C0A, 0x0000000A }, //es-PY -> es
+					{ 0x00003C0C, 0x0000000C }, //fr-HT -> fr
+					{ 0x00004001, 0x00000001 }, //ar-QA -> ar
+					{ 0x00004009, 0x00000009 }, //en-IN -> en
+					{ 0x0000400A, 0x0000000A }, //es-BO -> es
+					{ 0x00004409, 0x00000009 }, //en-MY -> en
+					{ 0x0000440A, 0x0000000A }, //es-SV -> es
+					{ 0x00004809, 0x00000009 }, //en-SG -> en
+					{ 0x0000480A, 0x0000000A }, //es-HN -> es
+					{ 0x00004C09, 0x00000009 }, //en-AE -> en
+					{ 0x00004C0A, 0x0000000A }, //es-NI -> es
+					{ 0x0000500A, 0x0000000A }, //es-PR -> es
+					{ 0x0000540A, 0x0000000A }, //es-US -> es
+					{ 0x0000580A, 0x0000000A }, //es-419 -> es
+					{ 0x00005C0A, 0x0000000A }, //es-CU -> es
 					{ 0x0000641A, 0x0000781A }, //bs-Cyrl -> bs
 					{ 0x0000681A, 0x0000781A }, //bs-Latn -> bs
 					{ 0x00006C1A, 0x00007C1A }, //sr-Cyrl -> sr
 					{ 0x0000701A, 0x00007C1A }, //sr-Latn -> sr
+					{ 0x0000703B, 0x0000003B }, //smn -> se
 					{ 0x0000742C, 0x0000002C }, //az-Cyrl -> az
+					{ 0x0000743B, 0x0000003B }, //sms -> se
+					{ 0x00007814, 0x00000014 }, //nn -> no
 					{ 0x0000782C, 0x0000002C }, //az-Latn -> az
+					{ 0x0000783B, 0x0000003B }, //sma -> se
 					{ 0x00007843, 0x00000043 }, //uz-Cyrl -> uz
 					{ 0x00007850, 0x00000050 }, //mn-Cyrl -> mn
 					{ 0x0000785D, 0x0000005D }, //iu-Cans -> iu
+					{ 0x0000785F, 0x0000005F }, //tzm-Tfng -> tzm
 					{ 0x00007C04, 0x00007804 }, //zh-Hant -> zh
+					{ 0x00007C14, 0x00000014 }, //nb -> no
 					{ 0x00007C28, 0x00000028 }, //tg-Cyrl -> tg
+					{ 0x00007C2E, 0x0000002E }, //dsb -> hsb
+					{ 0x00007C3B, 0x0000003B }, //smj -> se
 					{ 0x00007C43, 0x00000043 }, //uz-Latn -> uz
+					{ 0x00007C46, 0x00000046 }, //pa-Arab -> pa
 					{ 0x00007C50, 0x00000050 }, //mn-Mong -> mn
-					{ 0x00007C5D, 0x0000005D }, //iu-Latng -> iu
+					{ 0x00007C59, 0x00000059 }, //sd-Arab -> sd
+					{ 0x00007C5C, 0x0000005C }, //chr-Cher -> chr
+					{ 0x00007C5D, 0x0000005D }, //iu-Latn -> iu
 					{ 0x00007C5F, 0x0000005F }, //tzm-Latn -> tzm
+					{ 0x00007C67, 0x00000067 }, //ff-Latn -> ff
 					{ 0x00007C68, 0x00000068 }, //ha-Latn -> ha
+					{ 0x00007C86, 0x00000086 }, //quc-Latn -> quc
+					{ 0x00007C92, 0x00000092 }, //ku-Arab -> ku
 					{ 0x0001007F, 0x0000007F }, //x-IV_mathan ->  ""
-					{ 0x00010407, 0x00000007 }, //de-DE_phoneb -> de 
-					{ 0x0001040E, 0x0000000E }, //hu-HU_technl -> hu 
-					{ 0x00010437, 0x00000037 }, //ka-GE_modern -> ka 
-					{ 0x00020804, 0x00000004 }, //zh-CN_stroke -> zh-Hans 
-					{ 0x00021004, 0x00000004 }, //zh-SG_stroke -> zh-Hans 
-					{ 0x00021404, 0x00007C04 }, //zh-MO_stroke -> zh-Hant 
-					{ 0x00030404, 0x00007C04 }, //zh-TW_pronun -> zh-Hant 
-					{ 0x00040404, 0x00007C04 }, //zh-TW_radstr -> zh-Hant 
-					{ 0x00040411, 0x00000011 }, //ja-JP_radstr -> ja 
-					{ 0x00040C04, 0x00007C04 }, //zh-HK_radstr -> zh-Hant 
-					{ 0x00041404, 0x00007C04 }, //zh-MO_radstr -> zh-Hant 
+					{ 0x00010407, 0x00000007 }, //de-DE_phoneb -> de
+					{ 0x0001040E, 0x0000000E }, //hu-HU_technl -> hu
+					{ 0x00010437, 0x00000037 }, //ka-GE_modern -> ka
+					{ 0x00020804, 0x00000004 }, //zh-CN_stroke -> zh-Hans
+					{ 0x00021004, 0x00000004 }, //zh-SG_stroke -> zh-Hans
+					{ 0x00021404, 0x00007C04 }, //zh-MO_stroke -> zh-Hant
+					{ 0x00030404, 0x00007C04 }, //zh-TW_pronun -> zh-Hant
+					{ 0x00040404, 0x00007C04 }, //zh-TW_radstr -> zh-Hant
+					{ 0x00040411, 0x00000011 }, //ja-JP_radstr -> ja
+					{ 0x00040C04, 0x00007C04 }, //zh-HK_radstr -> zh-Hant
+					{ 0x00041404, 0x00007C04 }, //zh-MO_radstr -> zh-Hant
+					{ 0x00050804, 0x00000004 }, //zh-CN_phoneb -> zh-Hans
+					{ 0x00051004, 0x00000004 }, //zh-SG_phoneb -> zh-Hans
 				};
 
 
@@ -371,12 +440,16 @@ namespace YY
 					{ L"ba", L"ba-RU" },
 					{ L"be", L"be-BY" },
 					{ L"bg", L"bg-BG" },
+					{ L"bin", L"bin-NG" },
 					{ L"bn", L"bn-IN" },
 					{ L"bo", L"bo-CN" },
 					{ L"br", L"br-FR" },
+					{ L"bs", L"bs-Latn-BA" },
 					{ L"bs-Cyrl", L"bs-Cyrl-BA" },
 					{ L"bs-Latn", L"bs-Latn-BA" },
 					{ L"ca", L"ca-ES" },
+					{ L"chr", L"chr-Cher-US" },
+					{ L"chr-Cher", L"chr-Cher-US" },
 					{ L"co", L"co-FR" },
 					{ L"cs", L"cs-CZ" },
 					{ L"cy", L"cy-GB" },
@@ -384,12 +457,15 @@ namespace YY
 					{ L"de", L"de-DE" },
 					{ L"dsb", L"dsb-DE" },
 					{ L"dv", L"dv-MV" },
+					{ L"dz", L"dz-BT" },
 					{ L"el", L"el-GR" },
 					{ L"en", L"en-US" },
 					{ L"es", L"es-ES" },
 					{ L"et", L"et-EE" },
 					{ L"eu", L"eu-ES" },
 					{ L"fa", L"fa-IR" },
+					{ L"ff", L"ff-Latn-SN" },
+					{ L"ff-Latn", L"ff-Latn-SN" },
 					{ L"fi", L"fi-FI" },
 					{ L"fil", L"fil-PH" },
 					{ L"fo", L"fo-FO" },
@@ -398,20 +474,25 @@ namespace YY
 					{ L"ga", L"ga-IE" },
 					{ L"gd", L"gd-GB" },
 					{ L"gl", L"gl-ES" },
+					{ L"gn", L"gn-PY" },
 					{ L"gsw", L"gsw-FR" },
 					{ L"gu", L"gu-IN" },
+					{ L"ha", L"ha-Latn-NG" },
 					{ L"ha-Latn", L"ha-Latn-NG" },
+					{ L"haw", L"haw-US" },
 					{ L"he", L"he-IL" },
 					{ L"hi", L"hi-IN" },
 					{ L"hr", L"hr-HR" },
 					{ L"hsb", L"hsb-DE" },
 					{ L"hu", L"hu-HU" },
 					{ L"hy", L"hy-AM" },
+					{ L"ibb", L"ibb-NG" },
 					{ L"id", L"id-ID" },
 					{ L"ig", L"ig-NG" },
 					{ L"ii", L"ii-CN" },
 					{ L"is", L"is-IS" },
 					{ L"it", L"it-IT" },
+					{ L"iu", L"iu-Latn-CA" },
 					{ L"iu-Cans", L"iu-Cans-CA" },
 					{ L"iu-Latn", L"iu-Latn-CA" },
 					{ L"ja", L"ja-JP" },
@@ -422,7 +503,14 @@ namespace YY
 					{ L"kn", L"kn-IN" },
 					{ L"ko", L"ko-KR" },
 					{ L"kok", L"kok-IN" },
+					{ L"kr", L"kr-Latn-NG" },
+					{ L"ks", L"ks-Arab-IN" },
+					{ L"ks-Arab", L"ks-Arab-IN" },
+					{ L"ks-Deva", L"ks-Deva-IN" },
+					{ L"ku", L"ku-Arab-IQ" },
+					{ L"ku-Arab", L"ku-Arab-IQ" },
 					{ L"ky", L"ky-KG" },
+					{ L"la", L"la-VA" },
 					{ L"lb", L"lb-LU" },
 					{ L"lo", L"lo-LA" },
 					{ L"lt", L"lt-LT" },
@@ -433,10 +521,12 @@ namespace YY
 					{ L"mn", L"mn-MN" },
 					{ L"mn-Cyrl", L"mn-MN" },
 					{ L"mn-Mong", L"mn-Mong-CN" },
+					{ L"mni", L"mni-IN" },
 					{ L"moh", L"moh-CA" },
 					{ L"mr", L"mr-IN" },
 					{ L"ms", L"ms-MY" },
 					{ L"mt", L"mt-MT" },
+					{ L"my", L"my-MM" },
 					{ L"nb", L"nb-NO" },
 					{ L"ne", L"ne-NP" },
 					{ L"nl", L"nl-NL" },
@@ -444,12 +534,17 @@ namespace YY
 					{ L"no", L"nb-NO" },
 					{ L"nso", L"nso-ZA" },
 					{ L"oc", L"oc-FR" },
+					{ L"om", L"om-ET" },
 					{ L"or", L"or-IN" },
 					{ L"pa", L"pa-IN" },
+					{ L"pa-Arab", L"pa-Arab-PK" },
+					{ L"pap", L"pap-029" },
 					{ L"pl", L"pl-PL" },
 					{ L"prs", L"prs-AF" },
 					{ L"ps", L"ps-AF" },
 					{ L"pt", L"pt-BR" },
+					{ L"quc", L"quc-Latn-GT" },
+					{ L"quc-Latn", L"quc-Latn-GT" },
 					{ L"qut", L"qut-GT" },
 					{ L"quz", L"quz-BO" },
 					{ L"rm", L"rm-CH" },
@@ -458,6 +553,9 @@ namespace YY
 					{ L"rw", L"rw-RW" },
 					{ L"sa", L"sa-IN" },
 					{ L"sah", L"sah-RU" },
+					{ L"sd", L"sd-Arab-PK" },
+					{ L"sd-Arab", L"sd-Arab-PK" },
+					{ L"sd-Deva", L"sd-Deva-IN" },
 					{ L"se", L"se-NO" },
 					{ L"si", L"si-LK" },
 					{ L"sk", L"sk-SK" },
@@ -466,32 +564,43 @@ namespace YY
 					{ L"smj", L"smj-SE" },
 					{ L"smn", L"smn-FI" },
 					{ L"sms", L"sms-FI" },
+					{ L"so", L"so-SO" },
 					{ L"sq", L"sq-AL" },
 					{ L"sr", L"sr-Latn-RS" },
 					{ L"sr-Cyrl", L"sr-Cyrl-RS" },
 					{ L"sr-Latn", L"sr-Latn-RS" },
+					{ L"st", L"st-ZA" },
 					{ L"sv", L"sv-SE" },
 					{ L"sw", L"sw-KE" },
 					{ L"syr", L"syr-SY" },
 					{ L"ta", L"ta-IN" },
 					{ L"te", L"te-IN" },
+					{ L"tg", L"tg-Cyrl-TJ" },
 					{ L"tg-Cyrl", L"tg-Cyrl-TJ" },
 					{ L"th", L"th-TH" },
+					{ L"ti", L"ti-ER" },
 					{ L"tk", L"tk-TM" },
 					{ L"tn", L"tn-ZA" },
 					{ L"tr", L"tr-TR" },
+					{ L"ts", L"ts-ZA" },
 					{ L"tt", L"tt-RU" },
+					{ L"tzm", L"tzm-Latn-DZ" },
+					{ L"tzm-Arab", L"tzm-Arab-MA" },
 					{ L"tzm-Latn", L"tzm-Latn-DZ" },
+					{ L"tzm-Tfng", L"tzm-Tfng-MA" },
 					{ L"ug", L"ug-CN" },
 					{ L"uk", L"uk-UA" },
 					{ L"ur", L"ur-PK" },
 					{ L"uz", L"uz-Latn-UZ" },
 					{ L"uz-Cyrl", L"uz-Cyrl-UZ" },
 					{ L"uz-Latn", L"uz-Latn-UZ" },
+					{ L"ve", L"ve-ZA" },
 					{ L"vi", L"vi-VN" },
 					{ L"wo", L"wo-SN" },
 					{ L"xh", L"xh-ZA" },
+					{ L"yi", L"yi-001" },
 					{ L"yo", L"yo-NG" },
+					{ L"zh", L"zh-CN" },
 					{ L"zh-Hans", L"zh-CN" },
 					{ L"zh-Hant", L"zh-HK" },
 					{ L"zu", L"zu-ZA" },
@@ -574,6 +683,7 @@ namespace YY
 					{ 0x00000025, L"et" },
 					{ 0x00000026, L"lv" },
 					{ 0x00000027, L"lt" },
+					{ 0x00000028, L"tg" },
 					{ 0x00000029, L"fa" },
 					{ 0x0000002A, L"vi" },
 					{ 0x0000002B, L"hy" },
@@ -581,7 +691,10 @@ namespace YY
 					{ 0x0000002D, L"eu" },
 					{ 0x0000002E, L"hsb" },
 					{ 0x0000002F, L"mk" },
+					{ 0x00000030, L"st" },
+					{ 0x00000031, L"ts" },
 					{ 0x00000032, L"tn" },
+					{ 0x00000033, L"ve" },
 					{ 0x00000034, L"xh" },
 					{ 0x00000035, L"zu" },
 					{ 0x00000036, L"af" },
@@ -591,6 +704,7 @@ namespace YY
 					{ 0x0000003A, L"mt" },
 					{ 0x0000003B, L"se" },
 					{ 0x0000003C, L"ga" },
+					{ 0x0000003D, L"yi" },
 					{ 0x0000003E, L"ms" },
 					{ 0x0000003F, L"kk" },
 					{ 0x00000040, L"ky" },
@@ -614,16 +728,27 @@ namespace YY
 					{ 0x00000052, L"cy" },
 					{ 0x00000053, L"km" },
 					{ 0x00000054, L"lo" },
+					{ 0x00000055, L"my" },
 					{ 0x00000056, L"gl" },
 					{ 0x00000057, L"kok" },
+					{ 0x00000058, L"mni" },
+					{ 0x00000059, L"sd" },
 					{ 0x0000005A, L"syr" },
 					{ 0x0000005B, L"si" },
+					{ 0x0000005C, L"chr" },
+					{ 0x0000005D, L"iu" },
 					{ 0x0000005E, L"am" },
+					{ 0x0000005F, L"tzm" },
+					{ 0x00000060, L"ks" },
 					{ 0x00000061, L"ne" },
 					{ 0x00000062, L"fy" },
 					{ 0x00000063, L"ps" },
 					{ 0x00000064, L"fil" },
 					{ 0x00000065, L"dv" },
+					{ 0x00000066, L"bin" },
+					{ 0x00000067, L"ff" },
+					{ 0x00000068, L"ha" },
+					{ 0x00000069, L"ibb" },
 					{ 0x0000006A, L"yo" },
 					{ 0x0000006B, L"quz" },
 					{ 0x0000006C, L"nso" },
@@ -631,7 +756,15 @@ namespace YY
 					{ 0x0000006E, L"lb" },
 					{ 0x0000006F, L"kl" },
 					{ 0x00000070, L"ig" },
+					{ 0x00000071, L"kr" },
+					{ 0x00000072, L"om" },
+					{ 0x00000073, L"ti" },
+					{ 0x00000074, L"gn" },
+					{ 0x00000075, L"haw" },
+					{ 0x00000076, L"la" },
+					{ 0x00000077, L"so" },
 					{ 0x00000078, L"ii" },
+					{ 0x00000079, L"pap" },
 					{ 0x0000007A, L"arn" },
 					{ 0x0000007C, L"moh" },
 					{ 0x0000007E, L"br" },
@@ -642,11 +775,12 @@ namespace YY
 					{ 0x00000083, L"co" },
 					{ 0x00000084, L"gsw" },
 					{ 0x00000085, L"sah" },
-					{ 0x00000086, L"qut" },
+					{ 0x00000086, L"quc" },
 					{ 0x00000087, L"rw" },
 					{ 0x00000088, L"wo" },
-					{ 0x0000008C, L"prs" },
+					{ 0x0000008C, L"fa" },
 					{ 0x00000091, L"gd" },
+					{ 0x00000092, L"ku" },
 					{ 0x00000401, L"ar-SA" },
 					{ 0x00000402, L"bg-BG" },
 					{ 0x00000403, L"ca-ES" },
@@ -694,7 +828,10 @@ namespace YY
 					{ 0x0000042D, L"eu-ES" },
 					{ 0x0000042E, L"hsb-DE" },
 					{ 0x0000042F, L"mk-MK" },
+					{ 0x00000430, L"st-ZA" },
+					{ 0x00000431, L"ts-ZA" },
 					{ 0x00000432, L"tn-ZA" },
+					{ 0x00000433, L"ve-ZA" },
 					{ 0x00000434, L"xh-ZA" },
 					{ 0x00000435, L"zu-ZA" },
 					{ 0x00000436, L"af-ZA" },
@@ -703,6 +840,7 @@ namespace YY
 					{ 0x00000439, L"hi-IN" },
 					{ 0x0000043A, L"mt-MT" },
 					{ 0x0000043B, L"se-NO" },
+					{ 0x0000043D, L"yi-001" },
 					{ 0x0000043E, L"ms-MY" },
 					{ 0x0000043F, L"kk-KZ" },
 					{ 0x00000440, L"ky-KG" },
@@ -726,18 +864,27 @@ namespace YY
 					{ 0x00000452, L"cy-GB" },
 					{ 0x00000453, L"km-KH" },
 					{ 0x00000454, L"lo-LA" },
+					{ 0x00000455, L"my-MM" },
 					{ 0x00000456, L"gl-ES" },
 					{ 0x00000457, L"kok-IN" },
+					{ 0x00000458, L"mni-IN" },
+					{ 0x00000459, L"sd-Deva-IN" },
 					{ 0x0000045A, L"syr-SY" },
 					{ 0x0000045B, L"si-LK" },
+					{ 0x0000045C, L"chr-Cher-US" },
 					{ 0x0000045D, L"iu-Cans-CA" },
 					{ 0x0000045E, L"am-ET" },
+					{ 0x0000045F, L"tzm-Arab-MA" },
+					{ 0x00000460, L"ks-Arab" },
 					{ 0x00000461, L"ne-NP" },
 					{ 0x00000462, L"fy-NL" },
 					{ 0x00000463, L"ps-AF" },
 					{ 0x00000464, L"fil-PH" },
 					{ 0x00000465, L"dv-MV" },
+					{ 0x00000466, L"bin-NG" },
+					{ 0x00000467, L"ff-Latn-NG" },
 					{ 0x00000468, L"ha-Latn-NG" },
+					{ 0x00000469, L"ibb-NG" },
 					{ 0x0000046A, L"yo-NG" },
 					{ 0x0000046B, L"quz-BO" },
 					{ 0x0000046C, L"nso-ZA" },
@@ -745,7 +892,15 @@ namespace YY
 					{ 0x0000046E, L"lb-LU" },
 					{ 0x0000046F, L"kl-GL" },
 					{ 0x00000470, L"ig-NG" },
+					{ 0x00000471, L"kr-Latn-NG" },
+					{ 0x00000472, L"om-ET" },
+					{ 0x00000473, L"ti-ET" },
+					{ 0x00000474, L"gn-PY" },
+					{ 0x00000475, L"haw-US" },
+					{ 0x00000476, L"la-VA" },
+					{ 0x00000477, L"so-SO" },
 					{ 0x00000478, L"ii-CN" },
+					{ 0x00000479, L"pap-029" },
 					{ 0x0000047A, L"arn-CL" },
 					{ 0x0000047C, L"moh-CA" },
 					{ 0x0000047E, L"br-FR" },
@@ -755,14 +910,16 @@ namespace YY
 					{ 0x00000483, L"co-FR" },
 					{ 0x00000484, L"gsw-FR" },
 					{ 0x00000485, L"sah-RU" },
-					{ 0x00000486, L"qut-GT" },
+					{ 0x00000486, L"quc-Latn-GT" },
 					{ 0x00000487, L"rw-RW" },
 					{ 0x00000488, L"wo-SN" },
-					{ 0x0000048C, L"prs-AF" },
+					{ 0x0000048C, L"fa-AF" },
 					{ 0x00000491, L"gd-GB" },
+					{ 0x00000492, L"ku-Arab-IQ" },
 					{ 0x00000501, L"qps-ploc" },
 					{ 0x000005FE, L"qps-ploca" },
 					{ 0x00000801, L"ar-IQ" },
+					{ 0x00000803, L"ca-ES-valencia" },
 					{ 0x00000804, L"zh-CN" },
 					{ 0x00000807, L"de-CH" },
 					{ 0x00000809, L"en-GB" },
@@ -772,19 +929,31 @@ namespace YY
 					{ 0x00000813, L"nl-BE" },
 					{ 0x00000814, L"nn-NO" },
 					{ 0x00000816, L"pt-PT" },
+					{ 0x00000818, L"ro-MD" },
+					{ 0x00000819, L"ru-MD" },
 					{ 0x0000081A, L"sr-Latn-CS" },
 					{ 0x0000081D, L"sv-FI" },
+					{ 0x00000820, L"ur-IN" },
 					{ 0x0000082C, L"az-Cyrl-AZ" },
 					{ 0x0000082E, L"dsb-DE" },
+					{ 0x00000832, L"tn-BW" },
 					{ 0x0000083B, L"se-SE" },
 					{ 0x0000083C, L"ga-IE" },
 					{ 0x0000083E, L"ms-BN" },
 					{ 0x00000843, L"uz-Cyrl-UZ" },
 					{ 0x00000845, L"bn-BD" },
+					{ 0x00000846, L"pa-Arab-PK" },
+					{ 0x00000849, L"ta-LK" },
 					{ 0x00000850, L"mn-Mong-CN" },
+					{ 0x00000859, L"sd-Arab-PK" },
 					{ 0x0000085D, L"iu-Latn-CA" },
 					{ 0x0000085F, L"tzm-Latn-DZ" },
+					{ 0x00000860, L"ks-Deva-IN" },
+					{ 0x00000861, L"ne-IN" },
+					{ 0x00000867, L"ff-Latn-SN" },
 					{ 0x0000086B, L"quz-EC" },
+					{ 0x00000873, L"ti-ER" },
+					{ 0x00000901, L"qps-Latn-x-sh" },
 					{ 0x000009FF, L"qps-plocm" },
 					{ 0x00000C01, L"ar-EG" },
 					{ 0x00000C04, L"zh-HK" },
@@ -794,7 +963,10 @@ namespace YY
 					{ 0x00000C0C, L"fr-CA" },
 					{ 0x00000C1A, L"sr-Cyrl-CS" },
 					{ 0x00000C3B, L"se-FI" },
+					{ 0x00000C50, L"mn-Mong-MN" },
+					{ 0x00000C51, L"dz-BT" },
 					{ 0x00000C6B, L"quz-PE" },
+					{ 0x00001000, L"ks-Arab-IN" },
 					{ 0x00001001, L"ar-LY" },
 					{ 0x00001004, L"zh-SG" },
 					{ 0x00001007, L"de-LU" },
@@ -803,6 +975,7 @@ namespace YY
 					{ 0x0000100C, L"fr-CH" },
 					{ 0x0000101A, L"hr-BA" },
 					{ 0x0000103B, L"smj-NO" },
+					{ 0x0000105F, L"tzm-Tfng-MA" },
 					{ 0x00001401, L"ar-DZ" },
 					{ 0x00001404, L"zh-MO" },
 					{ 0x00001407, L"de-LI" },
@@ -820,37 +993,48 @@ namespace YY
 					{ 0x00001C01, L"ar-TN" },
 					{ 0x00001C09, L"en-ZA" },
 					{ 0x00001C0A, L"es-DO" },
+					{ 0x00001C0C, L"fr-029" },
 					{ 0x00001C1A, L"sr-Cyrl-BA" },
 					{ 0x00001C3B, L"sma-SE" },
 					{ 0x00002001, L"ar-OM" },
 					{ 0x00002009, L"en-JM" },
 					{ 0x0000200A, L"es-VE" },
+					{ 0x0000200C, L"fr-RE" },
 					{ 0x0000201A, L"bs-Cyrl-BA" },
 					{ 0x0000203B, L"sms-FI" },
 					{ 0x00002401, L"ar-YE" },
 					{ 0x00002409, L"en-029" },
 					{ 0x0000240A, L"es-CO" },
+					{ 0x0000240C, L"fr-CD" },
 					{ 0x0000241A, L"sr-Latn-RS" },
 					{ 0x0000243B, L"smn-FI" },
 					{ 0x00002801, L"ar-SY" },
 					{ 0x00002809, L"en-BZ" },
 					{ 0x0000280A, L"es-PE" },
+					{ 0x0000280C, L"fr-SN" },
 					{ 0x0000281A, L"sr-Cyrl-RS" },
 					{ 0x00002C01, L"ar-JO" },
 					{ 0x00002C09, L"en-TT" },
 					{ 0x00002C0A, L"es-AR" },
+					{ 0x00002C0C, L"fr-CM" },
 					{ 0x00002C1A, L"sr-Latn-ME" },
 					{ 0x00003001, L"ar-LB" },
 					{ 0x00003009, L"en-ZW" },
 					{ 0x0000300A, L"es-EC" },
+					{ 0x0000300C, L"fr-CI" },
 					{ 0x0000301A, L"sr-Cyrl-ME" },
 					{ 0x00003401, L"ar-KW" },
 					{ 0x00003409, L"en-PH" },
 					{ 0x0000340A, L"es-CL" },
+					{ 0x0000340C, L"fr-ML" },
 					{ 0x00003801, L"ar-AE" },
+					{ 0x00003809, L"en-ID" },
 					{ 0x0000380A, L"es-UY" },
+					{ 0x0000380C, L"fr-MA" },
 					{ 0x00003C01, L"ar-BH" },
+					{ 0x00003C09, L"en-HK" },
 					{ 0x00003C0A, L"es-PY" },
+					{ 0x00003C0C, L"fr-HT" },
 					{ 0x00004001, L"ar-QA" },
 					{ 0x00004009, L"en-IN" },
 					{ 0x0000400A, L"es-BO" },
@@ -858,9 +1042,12 @@ namespace YY
 					{ 0x0000440A, L"es-SV" },
 					{ 0x00004809, L"en-SG" },
 					{ 0x0000480A, L"es-HN" },
+					{ 0x00004C09, L"en-AE" },
 					{ 0x00004C0A, L"es-NI" },
 					{ 0x0000500A, L"es-PR" },
 					{ 0x0000540A, L"es-US" },
+					{ 0x0000580A, L"es-419" },
+					{ 0x00005C0A, L"es-CU" },
 					{ 0x0000641A, L"bs-Cyrl" },
 					{ 0x0000681A, L"bs-Latn" },
 					{ 0x00006C1A, L"sr-Cyrl" },
@@ -868,12 +1055,15 @@ namespace YY
 					{ 0x0000703B, L"smn" },
 					{ 0x0000742C, L"az-Cyrl" },
 					{ 0x0000743B, L"sms" },
+					{ 0x00007804, L"zh" },
 					{ 0x00007814, L"nn" },
+					{ 0x0000781A, L"bs" },
 					{ 0x0000782C, L"az-Latn" },
 					{ 0x0000783B, L"sma" },
 					{ 0x00007843, L"uz-Cyrl" },
 					{ 0x00007850, L"mn-Cyrl" },
 					{ 0x0000785D, L"iu-Cans" },
+					{ 0x0000785F, L"tzm-Tfng" },
 					{ 0x00007C04, L"zh-Hant" },
 					{ 0x00007C14, L"nb" },
 					{ 0x00007C1A, L"sr" },
@@ -881,10 +1071,16 @@ namespace YY
 					{ 0x00007C2E, L"dsb" },
 					{ 0x00007C3B, L"smj" },
 					{ 0x00007C43, L"uz-Latn" },
+					{ 0x00007C46, L"pa-Arab" },
 					{ 0x00007C50, L"mn-Mong" },
+					{ 0x00007C59, L"sd-Arab" },
+					{ 0x00007C5C, L"chr-Cher" },
 					{ 0x00007C5D, L"iu-Latn" },
 					{ 0x00007C5F, L"tzm-Latn" },
+					{ 0x00007C67, L"ff-Latn" },
 					{ 0x00007C68, L"ha-Latn" },
+					{ 0x00007C86, L"quc-Latn" },
+					{ 0x00007C92, L"ku-Arab" },
 					{ 0x0001007F, L"x-IV_mathan" },
 					{ 0x00010407, L"de-DE_phoneb" },
 					{ 0x0001040E, L"hu-HU_technl" },
@@ -897,6 +1093,8 @@ namespace YY
 					{ 0x00040411, L"ja-JP_radstr" },
 					{ 0x00040C04, L"zh-HK_radstr" },
 					{ 0x00041404, L"zh-MO_radstr" },
+					{ 0x00050804, L"zh-CN_phoneb" },
+					{ 0x00051004, L"zh-SG_phoneb" },
 				};
 
 				int bottom = 0;
@@ -1028,6 +1226,8 @@ namespace YY
 				{ L"be-BY", 0x00000423 },
 				{ L"bg", 0x00000002 },
 				{ L"bg-BG", 0x00000402 },
+				{ L"bin", 0x00000066 },
+				{ L"bin-NG", 0x00000466 },
 				{ L"bn", 0x00000045 },
 				{ L"bn-BD", 0x00000845 },
 				{ L"bn-IN", 0x00000445 },
@@ -1035,12 +1235,17 @@ namespace YY
 				{ L"bo-CN", 0x00000451 },
 				{ L"br", 0x0000007E },
 				{ L"br-FR", 0x0000047E },
+				{ L"bs", 0x0000781A },
 				{ L"bs-Cyrl", 0x0000641A },
 				{ L"bs-Cyrl-BA", 0x0000201A },
 				{ L"bs-Latn", 0x0000681A },
 				{ L"bs-Latn-BA", 0x0000141A },
 				{ L"ca", 0x00000003 },
 				{ L"ca-ES", 0x00000403 },
+				{ L"ca-ES-valencia", 0x00000803 },
+				{ L"chr", 0x0000005C },
+				{ L"chr-Cher", 0x00007C5C },
+				{ L"chr-Cher-US", 0x0000045C },
 				{ L"co", 0x00000083 },
 				{ L"co-FR", 0x00000483 },
 				{ L"cs", 0x00000005 },
@@ -1060,14 +1265,18 @@ namespace YY
 				{ L"dsb-DE", 0x0000082E },
 				{ L"dv", 0x00000065 },
 				{ L"dv-MV", 0x00000465 },
+				{ L"dz-BT", 0x00000C51 },
 				{ L"el", 0x00000008 },
 				{ L"el-GR", 0x00000408 },
 				{ L"en", 0x00000009 },
 				{ L"en-029", 0x00002409 },
+				{ L"en-AE", 0x00004C09 },
 				{ L"en-AU", 0x00000C09 },
 				{ L"en-BZ", 0x00002809 },
 				{ L"en-CA", 0x00001009 },
 				{ L"en-GB", 0x00000809 },
+				{ L"en-HK", 0x00003C09 },
+				{ L"en-ID", 0x00003809 },
 				{ L"en-IE", 0x00001809 },
 				{ L"en-IN", 0x00004009 },
 				{ L"en-JM", 0x00002009 },
@@ -1080,11 +1289,13 @@ namespace YY
 				{ L"en-ZA", 0x00001C09 },
 				{ L"en-ZW", 0x00003009 },
 				{ L"es", 0x0000000A },
+				{ L"es-419", 0x0000580A },
 				{ L"es-AR", 0x00002C0A },
 				{ L"es-BO", 0x0000400A },
 				{ L"es-CL", 0x0000340A },
 				{ L"es-CO", 0x0000240A },
 				{ L"es-CR", 0x0000140A },
+				{ L"es-CU", 0x00005C0A },
 				{ L"es-DO", 0x00001C0A },
 				{ L"es-EC", 0x0000300A },
 				{ L"es-ES", 0x00000C0A },
@@ -1106,7 +1317,12 @@ namespace YY
 				{ L"eu", 0x0000002D },
 				{ L"eu-ES", 0x0000042D },
 				{ L"fa", 0x00000029 },
+				{ L"fa-AF", 0x0000048C },
 				{ L"fa-IR", 0x00000429 },
+				{ L"ff", 0x00000067 },
+				{ L"ff-Latn", 0x00007C67 },
+				{ L"ff-Latn-NG", 0x00000467 },
+				{ L"ff-Latn-SN", 0x00000867 },
 				{ L"fi", 0x0000000B },
 				{ L"fi-FI", 0x0000040B },
 				{ L"fil", 0x00000064 },
@@ -1114,12 +1330,21 @@ namespace YY
 				{ L"fo", 0x00000038 },
 				{ L"fo-FO", 0x00000438 },
 				{ L"fr", 0x0000000C },
+				{ L"fr-029", 0x00001C0C },
 				{ L"fr-BE", 0x0000080C },
 				{ L"fr-CA", 0x00000C0C },
+				{ L"fr-CD", 0x0000240C },
 				{ L"fr-CH", 0x0000100C },
+				{ L"fr-CI", 0x0000300C },
+				{ L"fr-CM", 0x00002C0C },
 				{ L"fr-FR", 0x0000040C },
+				{ L"fr-HT", 0x00003C0C },
 				{ L"fr-LU", 0x0000140C },
+				{ L"fr-MA", 0x0000380C },
 				{ L"fr-MC", 0x0000180C },
+				{ L"fr-ML", 0x0000340C },
+				{ L"fr-RE", 0x0000200C },
+				{ L"fr-SN", 0x0000280C },
 				{ L"fy", 0x00000062 },
 				{ L"fy-NL", 0x00000462 },
 				{ L"ga", 0x0000003C },
@@ -1128,12 +1353,17 @@ namespace YY
 				{ L"gd-GB", 0x00000491 },
 				{ L"gl", 0x00000056 },
 				{ L"gl-ES", 0x00000456 },
+				{ L"gn", 0x00000074 },
+				{ L"gn-PY", 0x00000474 },
 				{ L"gsw", 0x00000084 },
 				{ L"gsw-FR", 0x00000484 },
 				{ L"gu", 0x00000047 },
 				{ L"gu-IN", 0x00000447 },
+				{ L"ha", 0x00000068 },
 				{ L"ha-Latn", 0x00007C68 },
 				{ L"ha-Latn-NG", 0x00000468 },
+				{ L"haw", 0x00000075 },
+				{ L"haw-US", 0x00000475 },
 				{ L"he", 0x0000000D },
 				{ L"he-IL", 0x0000040D },
 				{ L"hi", 0x00000039 },
@@ -1148,6 +1378,8 @@ namespace YY
 				{ L"hu-HU_technl", 0x0001040E },
 				{ L"hy", 0x0000002B },
 				{ L"hy-AM", 0x0000042B },
+				{ L"ibb", 0x00000069 },
+				{ L"ibb-NG", 0x00000469 },
 				{ L"id", 0x00000021 },
 				{ L"id-ID", 0x00000421 },
 				{ L"ig", 0x00000070 },
@@ -1159,6 +1391,7 @@ namespace YY
 				{ L"it", 0x00000010 },
 				{ L"it-CH", 0x00000810 },
 				{ L"it-IT", 0x00000410 },
+				{ L"iu", 0x0000005D },
 				{ L"iu-Cans", 0x0000785D },
 				{ L"iu-Cans-CA", 0x0000045D },
 				{ L"iu-Latn", 0x00007C5D },
@@ -1181,8 +1414,19 @@ namespace YY
 				{ L"ko-KR", 0x00000412 },
 				{ L"kok", 0x00000057 },
 				{ L"kok-IN", 0x00000457 },
+				{ L"kr", 0x00000071 },
+				{ L"kr-Latn-NG", 0x00000471 },
+				{ L"ks", 0x00000060 },
+				{ L"ks-Arab", 0x00000460 },
+				{ L"ks-Arab-IN", 0x00001000 },
+				{ L"ks-Deva-IN", 0x00000860 },
+				{ L"ku", 0x00000092 },
+				{ L"ku-Arab", 0x00007C92 },
+				{ L"ku-Arab-IQ", 0x00000492 },
 				{ L"ky", 0x00000040 },
 				{ L"ky-KG", 0x00000440 },
+				{ L"la", 0x00000076 },
+				{ L"la-VA", 0x00000476 },
 				{ L"lb", 0x0000006E },
 				{ L"lb-LU", 0x0000046E },
 				{ L"lo", 0x00000054 },
@@ -1202,6 +1446,9 @@ namespace YY
 				{ L"mn-MN", 0x00000450 },
 				{ L"mn-Mong", 0x00007C50 },
 				{ L"mn-Mong-CN", 0x00000850 },
+				{ L"mn-Mong-MN", 0x00000C50 },
+				{ L"mni", 0x00000058 },
+				{ L"mni-IN", 0x00000458 },
 				{ L"moh", 0x0000007C },
 				{ L"moh-CA", 0x0000047C },
 				{ L"mr", 0x0000004E },
@@ -1211,9 +1458,12 @@ namespace YY
 				{ L"ms-MY", 0x0000043E },
 				{ L"mt", 0x0000003A },
 				{ L"mt-MT", 0x0000043A },
+				{ L"my", 0x00000055 },
+				{ L"my-MM", 0x00000455 },
 				{ L"nb", 0x00007C14 },
 				{ L"nb-NO", 0x00000414 },
 				{ L"ne", 0x00000061 },
+				{ L"ne-IN", 0x00000861 },
 				{ L"ne-NP", 0x00000461 },
 				{ L"nl", 0x00000013 },
 				{ L"nl-BE", 0x00000813 },
@@ -1225,10 +1475,16 @@ namespace YY
 				{ L"nso-ZA", 0x0000046C },
 				{ L"oc", 0x00000082 },
 				{ L"oc-FR", 0x00000482 },
+				{ L"om", 0x00000072 },
+				{ L"om-ET", 0x00000472 },
 				{ L"or", 0x00000048 },
 				{ L"or-IN", 0x00000448 },
 				{ L"pa", 0x00000046 },
+				{ L"pa-Arab", 0x00007C46 },
+				{ L"pa-Arab-PK", 0x00000846 },
 				{ L"pa-IN", 0x00000446 },
+				{ L"pap", 0x00000079 },
+				{ L"pap-029", 0x00000479 },
 				{ L"pl", 0x00000015 },
 				{ L"pl-PL", 0x00000415 },
 				{ L"prs", 0x0000008C },
@@ -1238,9 +1494,13 @@ namespace YY
 				{ L"pt", 0x00000016 },
 				{ L"pt-BR", 0x00000416 },
 				{ L"pt-PT", 0x00000816 },
+				{ L"qps-Latn-x-sh", 0x00000901 },
 				{ L"qps-ploc", 0x00000501 },
 				{ L"qps-ploca", 0x000005FE },
 				{ L"qps-plocm", 0x000009FF },
+				{ L"quc", 0x00000086 },
+				{ L"quc-Latn", 0x00007C86 },
+				{ L"quc-Latn-GT", 0x00000486 },
 				{ L"qut", 0x00000086 },
 				{ L"qut-GT", 0x00000486 },
 				{ L"quz", 0x0000006B },
@@ -1250,8 +1510,10 @@ namespace YY
 				{ L"rm", 0x00000017 },
 				{ L"rm-CH", 0x00000417 },
 				{ L"ro", 0x00000018 },
+				{ L"ro-MD", 0x00000818 },
 				{ L"ro-RO", 0x00000418 },
 				{ L"ru", 0x00000019 },
+				{ L"ru-MD", 0x00000819 },
 				{ L"ru-RU", 0x00000419 },
 				{ L"rw", 0x00000087 },
 				{ L"rw-RW", 0x00000487 },
@@ -1259,6 +1521,10 @@ namespace YY
 				{ L"sa-IN", 0x0000044F },
 				{ L"sah", 0x00000085 },
 				{ L"sah-RU", 0x00000485 },
+				{ L"sd", 0x00000059 },
+				{ L"sd-Arab", 0x00007C59 },
+				{ L"sd-Arab-PK", 0x00000859 },
+				{ L"sd-Deva-IN", 0x00000459 },
 				{ L"se", 0x0000003B },
 				{ L"se-FI", 0x00000C3B },
 				{ L"se-NO", 0x0000043B },
@@ -1279,6 +1545,8 @@ namespace YY
 				{ L"smn-FI", 0x0000243B },
 				{ L"sms", 0x0000743B },
 				{ L"sms-FI", 0x0000203B },
+				{ L"so", 0x00000077 },
+				{ L"so-SO", 0x00000477 },
 				{ L"sq", 0x0000001C },
 				{ L"sq-AL", 0x0000041C },
 				{ L"sr", 0x00007C1A },
@@ -1292,6 +1560,8 @@ namespace YY
 				{ L"sr-Latn-CS", 0x0000081A },
 				{ L"sr-Latn-ME", 0x00002C1A },
 				{ L"sr-Latn-RS", 0x0000241A },
+				{ L"st", 0x00000030 },
+				{ L"st-ZA", 0x00000430 },
 				{ L"sv", 0x0000001D },
 				{ L"sv-FI", 0x0000081D },
 				{ L"sv-SE", 0x0000041D },
@@ -1301,33 +1571,48 @@ namespace YY
 				{ L"syr-SY", 0x0000045A },
 				{ L"ta", 0x00000049 },
 				{ L"ta-IN", 0x00000449 },
+				{ L"ta-LK", 0x00000849 },
 				{ L"te", 0x0000004A },
 				{ L"te-IN", 0x0000044A },
+				{ L"tg", 0x00000028 },
 				{ L"tg-Cyrl", 0x00007C28 },
 				{ L"tg-Cyrl-TJ", 0x00000428 },
 				{ L"th", 0x0000001E },
 				{ L"th-TH", 0x0000041E },
+				{ L"ti", 0x00000073 },
+				{ L"ti-ER", 0x00000873 },
+				{ L"ti-ET", 0x00000473 },
 				{ L"tk", 0x00000042 },
 				{ L"tk-TM", 0x00000442 },
 				{ L"tn", 0x00000032 },
+				{ L"tn-BW", 0x00000832 },
 				{ L"tn-ZA", 0x00000432 },
 				{ L"tr", 0x0000001F },
 				{ L"tr-TR", 0x0000041F },
+				{ L"ts", 0x00000031 },
+				{ L"ts-ZA", 0x00000431 },
 				{ L"tt", 0x00000044 },
 				{ L"tt-RU", 0x00000444 },
+				{ L"tzm", 0x0000005F },
+				{ L"tzm-Arab-MA", 0x0000045F },
 				{ L"tzm-Latn", 0x00007C5F },
 				{ L"tzm-Latn-DZ", 0x0000085F },
+				{ L"tzm-Tfng", 0x0000785F },
+				{ L"tzm-Tfng-MA", 0x0000105F },
 				{ L"ug", 0x00000080 },
 				{ L"ug-CN", 0x00000480 },
 				{ L"uk", 0x00000022 },
 				{ L"uk-UA", 0x00000422 },
 				{ L"ur", 0x00000020 },
+				{ L"ur-IN", 0x00000820 },
 				{ L"ur-PK", 0x00000420 },
 				{ L"uz", 0x00000043 },
 				{ L"uz-Cyrl", 0x00007843 },
 				{ L"uz-Cyrl-UZ", 0x00000843 },
 				{ L"uz-Latn", 0x00007C43 },
 				{ L"uz-Latn-UZ", 0x00000443 },
+				{ L"ve", 0x00000033 },
+				{ L"ve-ZA", 0x00000433 },
 				{ L"vi", 0x0000002A },
 				{ L"vi-VN", 0x0000042A },
 				{ L"wo", 0x00000088 },
@@ -1335,18 +1620,23 @@ namespace YY
 				{ L"x-IV_mathan", 0x0001007F },
 				{ L"xh", 0x00000034 },
 				{ L"xh-ZA", 0x00000434 },
+				{ L"yi", 0x0000003D },
+				{ L"yi-001", 0x0000043D },
 				{ L"yo", 0x0000006A },
 				{ L"yo-NG", 0x0000046A },
+				{ L"zh", 0x00007804 },
 				{ L"zh-CN", 0x00000804 },
+				{ L"zh-CN_phoneb", 0x00050804 },
 				{ L"zh-CN_stroke", 0x00020804 },
-				{ L"zh-HK", 0x00000C04 },
-				{ L"zh-HK_radstr", 0x00040C04 },
 				{ L"zh-Hans", 0x00000004 },
 				{ L"zh-Hant", 0x00007C04 },
+				{ L"zh-HK", 0x00000C04 },
+				{ L"zh-HK_radstr", 0x00040C04 },
 				{ L"zh-MO", 0x00001404 },
 				{ L"zh-MO_radstr", 0x00041404 },
 				{ L"zh-MO_stroke", 0x00021404 },
 				{ L"zh-SG", 0x00001004 },
+				{ L"zh-SG_phoneb", 0x00051004 },
 				{ L"zh-SG_stroke", 0x00021004 },
 				{ L"zh-TW", 0x00000404 },
 				{ L"zh-TW_pronun", 0x00030404 },


### PR DESCRIPTION
相关 issue: #73

在 Win 11 23H2 环境下，调用系统的 API 以遍历所有的 LCID，使用得到的结果更新了代码中使用的表格。