### PR TITLE
恢复对c++20的兼容

### DIFF
--- a/src/Thunks/WinHttp.hpp
+++ b/src/Thunks/WinHttp.hpp
@@ -1,5 +1,7 @@
 ﻿#include <winhttp.h>
 
+#pragma comment(lib, "winhttp.lib")
+
 namespace YY
 {
     namespace Thunks

--- a/src/Thunks/YY_Thunks.cpp
+++ b/src/Thunks/YY_Thunks.cpp
@@ -99,6 +99,8 @@
 #include <psapi.h>
 #include <winnls.h>
 
+#include <utility>
+
 EXTERN_C
 BOOLEAN
 __stdcall

--- a/src/Thunks/bcrypt.hpp
+++ b/src/Thunks/bcrypt.hpp
@@ -1292,6 +1292,8 @@ namespace YY
         template<typename BCryptAlgorithmType, typename BCryptKeyType, DWORD kDefaultCryptMode, DWORD kDefaultBlockSize>
         struct BCryptKeyAlgorithm : public BCryptAlgorithmByCryptoAPI<BCryptAlgorithmType>
         {
+            DWORD& uCryptMode = BCryptAlgorithm::uCryptMode;
+            DWORD& uEffectiveKeyBitCount = BCryptAlgorithm::uEffectiveKeyBitCount;
             BCryptKeyAlgorithm()
             {
                 uCryptMode = kDefaultCryptMode;

--- a/src/YY-Thunks.UnitTest/WinHttp.UnitTest.cpp
+++ b/src/YY-Thunks.UnitTest/WinHttp.UnitTest.cpp
@@ -1,8 +1,6 @@
 ﻿#include "pch.h"
 #include "Thunks/WinHttp.hpp"
 
-#pragma comment(lib, "winhttp.lib")
-
 namespace WinHppt
 {
     std::wstring ToString(const WINHTTP_PROXY_RESULT_ENTRY& _Item)

--- a/src/YY-Thunks.UnitTest/WinHttp.UnitTest.cpp
+++ b/src/YY-Thunks.UnitTest/WinHttp.UnitTest.cpp
@@ -133,7 +133,7 @@ namespace WinHppt
         {
             static const WINHTTP_PROXY_RESULT_ENTRY kTargetEntries[] =
             {
-                {1, 0, INTERNET_SCHEME_HTTP, L"192.168.18.193", 1081 },
+                {1, 0, INTERNET_SCHEME_HTTP, (PWSTR)L"192.168.18.193", 1081 },
             };
 
             struct TestInfo
@@ -192,8 +192,8 @@ namespace WinHppt
         {
             static const WINHTTP_PROXY_RESULT_ENTRY kTargetEntries[] =
             {
-                {1, 0, INTERNET_SCHEME_HTTP, L"192.168.18.193", 80 },
-                {1, 0, INTERNET_SCHEME_HTTP, L"192.168.18.194", 100 },
+                {1, 0, INTERNET_SCHEME_HTTP, (PWSTR)L"192.168.18.193", 80 },
+                {1, 0, INTERNET_SCHEME_HTTP, (PWSTR)L"192.168.18.194", 100 },
             };
 
             struct TestInfo
@@ -252,7 +252,7 @@ namespace WinHppt
         {
             static const WINHTTP_PROXY_RESULT_ENTRY kTargetEntries[] =
             {
-                {1, 0, INTERNET_SCHEME_HTTPS, L"192.168.18.193", 80 },
+                {1, 0, INTERNET_SCHEME_HTTPS, (PWSTR)L"192.168.18.193", 80 },
             };
 
             struct TestInfo
@@ -312,9 +312,9 @@ namespace WinHppt
         {
             static const WINHTTP_PROXY_RESULT_ENTRY kTargetEntries[] =
             {
-                {1, 0, INTERNET_SCHEME_HTTPS, L"192.168.18.193", 80 },
-                {1, 0, INTERNET_SCHEME_HTTPS, L"192.168.18.194", 102 },
-                {1, 0, INTERNET_SCHEME_HTTP, L"192.168.18.195", 103 },
+                {1, 0, INTERNET_SCHEME_HTTPS, (PWSTR)L"192.168.18.193", 80 },
+                {1, 0, INTERNET_SCHEME_HTTPS, (PWSTR)L"192.168.18.194", 102 },
+                {1, 0, INTERNET_SCHEME_HTTP, (PWSTR)L"192.168.18.195", 103 },
             };
 
             struct TestInfo


### PR DESCRIPTION
```cpp
// ConsoleApplication1.cpp : 此文件包含 "main" 函数。程序执行将在此处开始并结束。
//

#include <windows.h>


struct BCryptAlgorithm
{
	DWORD uCryptMode = 0;
	DWORD uEffectiveKeyBitCount = 0;
	BCryptAlgorithm()
	{

	}
};

template<typename BCryptAlgorithmType>
struct BCryptAlgorithmByCryptoAPI : BCryptAlgorithm
{
	BCryptAlgorithmByCryptoAPI()
	{

	}
};

template<typename BCryptAlgorithmType, typename BCryptKeyType, DWORD kDefaultCryptMode, DWORD kDefaultBlockSize>
struct BCryptKeyAlgorithm : public BCryptAlgorithmByCryptoAPI<BCryptAlgorithmType>
{
	BCryptKeyAlgorithm()
	{
		uCryptMode = 0;
	}
};

int main()
{

}

```

提取报错的代码，发现在gcc中即使指定c++14也会报错：
![image](https://github.com/Chuyu-Team/YY-Thunks/assets/20564099/1d903105-88de-449c-9299-6151a9c7abfd)

clang时指定c++14时不会报错，但是指定c++20时会有警告：
![image](https://github.com/Chuyu-Team/YY-Thunks/assets/20564099/c3fbbbf1-2b5a-418f-a19c-19f271a8766e)

vc的报错：
![image](https://github.com/Chuyu-Team/YY-Thunks/assets/20564099/9bd60245-5c91-4d0b-9843-8376d893f333)
