### PR TITLE
Fix some Windows Runtime API fallback behavior to follow the previous C++/WinRT fallback implementations.

### DIFF
--- a/ThunksList.md
+++ b/ThunksList.md
@@ -77,7 +77,7 @@
 | RoActivateInstance                         | 不存在时，返回 E_NOTIMPL。
 | RoRegisterActivationFactories              | 不存在时，返回 E_NOTIMPL。
 | RoRevokeActivationFactories                | 不存在时，什么也不做。
-| RoGetActivationFactory                     | 不存在时，返回 E_NOTIMPL。
+| RoGetActivationFactory                     | 不存在时，返回 CLASS_E_CLASSNOTAVAILABLE
 | RoRegisterForApartmentShutdown             | 不存在时，返回 E_NOTIMPL。
 | RoUnregisterForApartmentShutdown           | 不存在时，返回 E_NOTIMPL。
 | RoGetApartmentIdentifier                   | 不存在时，返回 E_NOTIMPL。
@@ -85,8 +85,8 @@
 ## api-ms-win-core-winrt-error-l1-1-0.dll
 | 函数                                       | Fallback
 | ----                                       | -----------
-| RoOriginateError                           | 不存在时，返回 FALSE.
-| RoOriginateErrorW                          | 不存在时，返回 FALSE.
+| RoOriginateError                           | 不存在时，返回 TRUE.
+| RoOriginateErrorW                          | 不存在时，返回 TRUE.
 
 ## api-ms-win-core-winrt-string-l1-1-0.dll
 | 函数                                       | Fallback

--- a/src/Thunks/api-ms-win-core-winrt-error.hpp
+++ b/src/Thunks/api-ms-win-core-winrt-error.hpp
@@ -24,7 +24,10 @@ namespace YY
 				return pRoOriginateError(error, message);
 			}
 
-			return FALSE;
+            // According to the C++/WinRT fallback implementation, we should
+            // return TRUE to tell the caller that the error message was
+            // reported successfully.
+			return TRUE;
 		}
 #endif
 
@@ -50,7 +53,10 @@ namespace YY
 				return pRoOriginateErrorW(error, cchMax, message);
 			}
 
-			return FALSE;
+            // According to the C++/WinRT fallback implementation, we should
+            // return TRUE to tell the caller that the error message was
+            // reported successfully.
+            return TRUE;
 		}
 #endif
 	}

--- a/src/Thunks/api-ms-win-core-winrt.hpp
+++ b/src/Thunks/api-ms-win-core-winrt.hpp
@@ -152,8 +152,9 @@ namespace YY
 			if (factory)
 				*factory = nullptr;
 
-			return E_NOTIMPL;
-
+            // According to the C++/WinRT fallback implementation, we should
+            // return CLASS_E_CLASSNOTAVAILABLE.
+			return CLASS_E_CLASSNOTAVAILABLE;
 		}
 #endif
 


### PR DESCRIPTION
In general, following the Microsoft's behaviors for avoiding some issues.

## Changed APIs

- RoOriginateError
- RoOriginateErrorW
- RoGetActivationFactory

Kenji Mouri