### PR TITLE
修正kernel32模块中的几个API函数的系统起始支持版本号

### DIFF
--- a/src/Thunks/api-ms-win-core-fibers.hpp
+++ b/src/Thunks/api-ms-win-core-fibers.hpp
@@ -410,10 +410,10 @@ namespace YY::Thunks
 #endif
 
 
-#if (YY_Thunks_Target < __WindowsNT6)
+#if (YY_Thunks_Target < __WindowsNT5_2)
 
     //Minimum supported client	Windows Vista [desktop apps | UWP apps]
-    //Minimum supported server	Windows Server 2008 [desktop apps | UWP apps]
+    //Minimum supported server	Windows Server 2003 [desktop apps | UWP apps]
     __DEFINE_THUNK(
     kernel32,
     8,

--- a/src/Thunks/api-ms-win-core-localization.hpp
+++ b/src/Thunks/api-ms-win-core-localization.hpp
@@ -2463,10 +2463,10 @@
 #endif
 
 
-#if (YY_Thunks_Target < __WindowsNT6)
+#if (YY_Thunks_Target < __WindowsNT5_2)
 
     //Minimum supported client	Windows Vista [desktop apps | UWP apps]
-    //Minimum supported server	Windows Server 2008 [desktop apps | UWP apps]
+    //Minimum supported server	Windows Server 2003 [desktop apps | UWP apps]
     __DEFINE_THUNK(
     kernel32,
     20,

--- a/src/Thunks/api-ms-win-core-wow64.hpp
+++ b/src/Thunks/api-ms-win-core-wow64.hpp
@@ -78,9 +78,9 @@ namespace YY::Thunks
 #endif
 
 
-#if (YY_Thunks_Target < __WindowsNT5_2_SP1)
+#if (YY_Thunks_Target < __WindowsNT5_1)
 
-    //Windows XP with SP2, Windows Server 2003 with SP1
+    //Windows XP, Windows Server 2003
     __DEFINE_THUNK(
     kernel32,
     8,


### PR DESCRIPTION
ConvertThreadToFiberEx
https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-convertthreadtofiberex

IsNLSDefinedString
![image](https://github.com/user-attachments/assets/4ecce093-41a1-497a-8f4f-1be33c1fdf67)

IsWow64Process
[xp_rtm_kernel32.zip](https://github.com/user-attachments/files/17001774/xp_rtm_kernel32.zip)
