### PR TITLE
修正在低版本系统上如果用户已经加载了一个用户目录下的指定名称的模块时，之后try_get_module函数并不能加载到系统目录下的该名称的模块的问题

### DIFF
--- a/src/Thunks/YY_Thunks.cpp
+++ b/src/Thunks/YY_Thunks.cpp
@@ -1197,8 +1197,13 @@ static HMODULE __fastcall try_get_module(volatile HMODULE* pModule, const wchar_
                 }
                 else
                 {
-                    auto _sModuleName = YY::Thunks::internal::MakeNtString(module_name);
-                    LdrLoadDll(szFilePathBuffer, nullptr, &_sModuleName, &new_handle);
+                    wchar_t szStringBuffer[MAX_PATH];
+                    YY::Thunks::internal::StringBuffer<wchar_t> _StringBuffer(szStringBuffer, _countof(szStringBuffer));
+                    _StringBuffer.AppendString(szFilePathBuffer);
+                    _StringBuffer.AppendChar(L'\\');
+                    _StringBuffer.AppendString(module_name);
+                    auto _sModuleName = YY::Thunks::internal::MakeNtString(szStringBuffer);
+                    LdrLoadDll(nullptr, nullptr, &_sModuleName, &new_handle);
                 }
             }
             else


### PR DESCRIPTION
使用类似下面的示例：
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/dbbb8108-e83c-44ca-9425-3d61272dd57f">
先加载一个程序目录下的version.dll（如群文件中我提供的远程调试器压缩包中的versiXP.dll改名为version.dll），
然后调用YY-Thunks中实现的GetFileVersionInfosizeEx函数，会触发到try_get_module函数被调用，而在低版本系统上（如Windows2003），会导致触发到下图的代码：
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/5a75cc4d-2bef-4ed7-b0a0-631a9ab12ebe">
即LdrLoadDll被调用，而目前代码会导致获取到的模块句柄是程序目录下的version.dll的（如上图中new_handle中值所示）
这并非程序所预期，因此算是个问题。

我这里的延申问题：
因为这里这个问题，在我[Win2K3-New](https://github.com/sonyps5201314/YY-Thunks/tree/Win2K3-New)分支上，由于有下面这段代码：
```cpp
    void* new_fp = try_get_proc_address_from_first_available_module(_ProcInfo);
    if (new_fp)
    {
        PIMAGE_DOS_HEADER pImageBase = &__ImageBase;
        PIMAGE_NT_HEADERS pNtHeaders = (PIMAGE_NT_HEADERS)((PBYTE)pImageBase + pImageBase->e_lfanew);
        if ((ULONG_PTR)new_fp >= (ULONG_PTR)pImageBase &&
            (ULONG_PTR)new_fp < (ULONG_PTR)pImageBase + pNtHeaders->OptionalHeader.SizeOfImage)
        {
            new_fp = nullptr;
        }
    }
```
会进行API函数指针返回值判断，如果函数是本模块中的就认为该系统下不存在该API，这里因为LdrLoadDll返回了用户目录下的version.dll中的实现(没直接指向本模块KernelEx.dll(YY-Thunks的容器)中的实现，本Windows2003系统目录下的version.dll已经修改，导出了`GetFileVersionInfoSizeExW=KernelEx.GetFileVersionInfoSizeExW`这个函数，即指向了KernelEx)，因此被误认为该系统存在这个API了，因此出现了如下图的无限递归而崩溃的问题。
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/47bcb8b0-7b34-49c1-8216-94afb6ffbddb">

