### PR TITLE
Add WSAIoctl emulation for SIO_BASE_HANDLE

### DIFF
--- a/src/Thunks/WS2_32.hpp
+++ b/src/Thunks/WS2_32.hpp
@@ -1,6 +1,5 @@
 ﻿#include <winsock2.h>
 #include <ws2tcpip.h>
-#include <VersionHelpers.h>
 
 #ifdef FreeAddrInfoEx
 #undef FreeAddrInfoEx
@@ -1491,7 +1490,7 @@ namespace YY::Thunks
         {
             const auto result = pWSAIoctl(s, dwIoControlCode, lpvInBuffer, cbInBuffer, lpvOutBuffer, cbOutBuffer, lpcbBytesReturned, lpOverlapped, lpCompletionRoutine);
 
-            if (!IsWindowsVistaOrGreater()) 
+            if (internal::GetSystemVersion() < internal::MakeVersion(6, 0)) 
             {
                 // SIO_BASE_HANDLE is defined in the Mswsock.h header file and supported on Windows Vista and later.
                 // So while we do have layered service providers in Windows XP or earlier, this specific io control is not supported. 


### PR DESCRIPTION
This fixes WSAIoctl for SIO_BASE_HANDLE issue, which gets the "base raw handle" over the entire [Layered Service Provider](https://en.wikipedia.org/wiki/Layered_Service_Provider) stack, but LSP is actually deprecated since Windows Server 2012, and we can effectively return the raw socket. Given that the actual IOCTL needed Windows Vista to work, there is no other way to correctly emulate this behavior without hooking into ws2_32.dll, but this IOCTL is rare enough to not return the socket itself anyway.

Partially fixes #80.