### PR TITLE
Use QueueUserAPC to run NtCancelIoFile on each thread

### DIFF
--- a/src/Thunks/ntdll.hpp
+++ b/src/Thunks/ntdll.hpp
@@ -24,7 +24,7 @@ namespace YY::Thunks
         if (io != nullptr) 
         {
             // Not supported
-            return STATUS_NOT_SUPPORTED;
+            return STATUS_NOT_FOUND;
         }
 
         internal::StringBuffer<char> _Buffer;

--- a/src/Thunks/ntdll.hpp
+++ b/src/Thunks/ntdll.hpp
@@ -22,6 +22,7 @@ namespace YY::Thunks
         }
         
         auto currentTid = GetCurrentThreadId();
+        auto currentPid = GetCurrentProcessId();
         HANDLE h = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, GetCurrentProcessId());
         if (h != INVALID_HANDLE_VALUE)
         {
@@ -31,7 +32,7 @@ namespace YY::Thunks
             {
                 do
                 {
-                    if (te.th32ThreadID == currentTid)
+                    if (te.th32ThreadID == currentTid || te.th32OwnerProcessID != currentPid)
                     {
                         continue;
                     }

--- a/src/Thunks/ntdll.hpp
+++ b/src/Thunks/ntdll.hpp
@@ -1,4 +1,4 @@
-#include <tlhelp32.h>
+﻿#include <tlhelp32.h>
 namespace YY::Thunks
 {
 #if (YY_Thunks_Target < __WindowsNT6)
@@ -39,7 +39,7 @@ namespace YY::Thunks
                     if (threadHandle != INVALID_HANDLE_VALUE)
                     {
                         QueueUserAPC([](ULONG_PTR param)
-                                     { CancelIo((HANDLE)param); }, threadHandle, (ULONG_PTR)HANDLE);
+                                     { CancelIo((HANDLE)param); }, threadHandle, (ULONG_PTR)handle);
                         CloseHandle(threadHandle);
                     }
                 } while (Thread32Next(h, &te));

--- a/src/Thunks/ntdll.hpp
+++ b/src/Thunks/ntdll.hpp
@@ -20,14 +20,17 @@ namespace YY::Thunks
         {
             return _pfnNtCancelIoFileEx(handle, io, io_status);
         }
-
-
+        
+        auto currentTid = GetCurrentThreadId();
         HANDLE h = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, GetCurrentProcessId());
         if (h != INVALID_HANDLE_VALUE) {
             THREADENTRY32 te;
             te.dwSize = sizeof(te);
             if (Thread32First(h, &te)) {
                 do {
+                    if (te.th32ThreadID == currentTid) {
+                        continue;
+                    }
                     HANDLE threadHandle = OpenThread(THREAD_SET_CONTEXT, FALSE, te.th32ThreadID);
                     if (threadHandle != INVALID_HANDLE_VALUE) {
                         struct CancelIoData {


### PR DESCRIPTION
Since NtCancelIoFileEx will **cancel all ongoing requests of the entire process**:

> **The NTCancelIoFileEx function allows you to cancel requests in threads other than the calling thread**. The [NtCancelIoFile](https://learn.microsoft.com/en-us/windows/win32/devnotes/nt-cancel-io-file) function only cancels requests in the same thread that called the NtCancelIoFile function. NtCancelIoFileEx cancels only outstanding I/O on the handle, it does not change the state of the handle; this means that you cannot rely on the state of the handle because you cannot know whether the operation was completed successfully or canceled.

This means the mere call to NtCancelIoFile in the `NtCancelIoFileEx` implementation is not enough, because **`NtCancelIoFile` only impacts the current calling thread**. We can workaround this by [injecting an APC call](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-queueuserapc) to each thread of the current process (if we can open it with THREAD_SET_CONTEXT) and then cancelling the I/O request under the impersonation of that thread, which eventually cancels all ongoing I/O unless it is networked, which is a very rare case (unless you work with SMB).

Partially fixes https://github.com/Chuyu-Team/YY-Thunks/issues/80, for mio to run without having to resort to single threaded runtime