### PR TITLE
Strip WSA_FLAG_NO_HANDLE_INHERIT on system < Windows 7 SP1

### DIFF
--- a/src/Thunks/WS2_32.hpp
+++ b/src/Thunks/WS2_32.hpp
@@ -1,5 +1,6 @@
 ﻿#include <winsock2.h>
 #include <ws2tcpip.h>
+#include <VersionHelpers.h>
 
 #ifdef FreeAddrInfoEx
 #undef FreeAddrInfoEx
@@ -1484,8 +1485,12 @@ namespace YY::Thunks
     {
         if (auto const pWSASocketW = try_get_WSASocketW())
         {
-            // This flag is supported on Windows 7 with SP1, Windows Server 2008 R2 with SP1, and later
-            dwFlags &= ~WSA_FLAG_NO_HANDLE_INHERIT;
+            if (!IsWindows7SP1OrGreater()) 
+            {
+                // This flag is supported on Windows 7 with SP1, Windows Server 2008 R2 with SP1, and later
+                // So we strip it to prevent error
+                dwFlags &= ~WSA_FLAG_NO_HANDLE_INHERIT;
+            }
             return pWSASocketW(af, type, protocol, lpProtocolInfo, g, dwFlags);
         }
         return INVALID_SOCKET;

--- a/src/Thunks/WS2_32.hpp
+++ b/src/Thunks/WS2_32.hpp
@@ -1463,6 +1463,30 @@ namespace YY::Thunks
     }
 #endif
 
+#if (YY_Thunks_Target < __WindowsNT6_1_SP1)
+    __DEFINE_THUNK(
+    ws2_32,
+    24,
+    SOCKET,
+    WSAAPI,
+    WSASocketW,
+        _In_ int af,
+        _In_ int type,
+        _In_ int protocol,
+        _In_opt_ LPWSAPROTOCOL_INFOW lpProtocolInfo,
+        _In_ GROUP g,
+        _In_ DWORD dwFlags
+        )
+    {
+        if (auto const pWSASocketW = try_get_WSASocketW())
+        {
+            // This flag is supported on Windows 7 with SP1, Windows Server 2008 R2 with SP1, and later
+            dwFlags &= ~WSA_FLAG_NO_HANDLE_INHERIT;
+            return pWSASocketW(af, type, protocol, lpProtocolInfo, g, dwFlags);
+        }
+        return INVALID_SOCKET;
+    }
+#endif
 
 #if (YY_Thunks_Target < __WindowsNT6_2)
 

--- a/src/Thunks/WS2_32.hpp
+++ b/src/Thunks/WS2_32.hpp
@@ -1464,6 +1464,10 @@ namespace YY::Thunks
 #endif
 
 #if (YY_Thunks_Target < __WindowsNT6_1_SP1)
+#ifndef WSA_FLAG_NO_HANDLE_INHERIT
+#define WSA_FLAG_NO_HANDLE_INHERIT    0x80
+#endif
+
     __DEFINE_THUNK(
     ws2_32,
     24,

--- a/src/Thunks/WS2_32.hpp
+++ b/src/Thunks/WS2_32.hpp
@@ -1,6 +1,5 @@
 ﻿#include <winsock2.h>
 #include <ws2tcpip.h>
-#include <VersionHelpers.h>
 
 #ifdef FreeAddrInfoEx
 #undef FreeAddrInfoEx


### PR DESCRIPTION
Partially fixes #80, especially need to strip it for reqwest, and by extension socket2 to run. That API call only exists on Windows 7 SP1 and above, so `socket2` calls to it breaks by returning unsupported. We don't care about socket inheritance at this point.

https://github.com/rust-lang/socket2/blob/3a938932829ea6ee3025d2d7a86c7b095c76e6c3/src/sys/windows.rs#L253

https://github.com/rust-lang/socket2/blob/3a938932829ea6ee3025d2d7a86c7b095c76e6c3/src/sys/windows.rs#L406
