### PR TITLE
Add some WinRT interfaces to api-ms-win-core-winrt.

### DIFF
--- a/ThunksList.md
+++ b/ThunksList.md
@@ -112,10 +112,10 @@
 | ----                                       | -----------
 | RoInitialize                               | 调用 CoInitializeEx。
 | RoUninitialize                             | 调用 CoUninitialize。
-| RoActivateInstance                         | 返回 E_NOTIMPL。
+| RoActivateInstance                         | 内部实现。
 | RoRegisterActivationFactories              | 返回 E_NOTIMPL。
 | RoRevokeActivationFactories                | 什么也不做。
-| RoGetActivationFactory                     | 返回 CLASS_E_CLASSNOTAVAILABLE
+| RoGetActivationFactory                     | 内部实现。
 | RoRegisterForApartmentShutdown             | 返回 E_NOTIMPL。
 | RoUnregisterForApartmentShutdown           | 返回 E_NOTIMPL。
 | RoGetApartmentIdentifier                   | 返回 E_NOTIMPL。

--- a/src/Thunks/api-ms-win-core-winrt.hpp
+++ b/src/Thunks/api-ms-win-core-winrt.hpp
@@ -29,14 +29,16 @@ public:
     {
         if (NULL == ppv)
             return E_POINTER;
+    
         if ((IID_IUnknown == riid)
             || (__uuidof(ILauncherStatics) == riid)
             || (__uuidof(IInspectable) == riid) || (__uuidof(IAgileObject) == riid))
         {
             AddRef();
-            *ppv = (fakeShellBridge1*)(&fbridge1);
+            *ppv = (ILauncherStatics*)(this);
             return S_OK;
         }
+    
         return E_NOINTERFACE;
     };
 
@@ -50,54 +52,55 @@ public:
         return 1; 
     };
 
-    STDMETHODIMP_(HRESULT) GetIids(
+    STDMETHODIMP HRESULT GetIids(
         _Out_ ULONG* iidCount,
         _Out_ IID** iids) 
     {
         IID *Array;
-    	ULONG Count;
-    
-        Count = 1;
-    
+        ULONG Count = 1;
     	Array = (IID *) CoTaskMemAlloc(Count * sizeof(IID));
+        
     	if (!Array) {
     		return E_OUTOFMEMORY;
     	}
-    
-    	*iidCount = Count;
+        
     	Array[0] = __uuidof(ILauncherStatics);
+        
+    	*iidCount = Count;
+        *iids = Array;
     
     	return S_OK;
     };
 
-    STDMETHODIMP_(HRESULT) GetRuntimeClassName(
+    STDMETHODIMP HRESULT GetRuntimeClassName(
         _Out_ HSTRING* className)
     {
         PCWSTR Name = L"Windows.System.Launcher";
         return WindowsCreateString(Name, (ULONG) wcslen(Name), className);
     };
 
-    STDMETHODIMP_(HRESULT) GetTrustLevel(
+    STDMETHODIMP HRESULT GetTrustLevel(
         _Out_ TrustLevel* trustLevel) 
     {
         *trustLevel = BaseTrust;
         return S_OK;
     };
 
-    STDMETHODIMP_(HRESULT) TreatAsUntrusted(
+    STDMETHODIMP HRESULT TreatAsUntrusted(
         boolean* value)
     {
-        return 7;
+        *value = FALSE;
+        return S_OK;
     };
 
-    STDMETHODIMP_(HRESULT) LaunchFileAsync(
+    STDMETHODIMP HRESULT LaunchFileAsync(
         _In_ IUnknown* file, 
         _Out_ IAsyncOperation** operation)
     {
         return E_NOTIMPL;
     };
 
-    STDMETHODIMP_(HRESULT) LaunchFileWithOptionsAsync(
+    STDMETHODIMP HRESULT LaunchFileWithOptionsAsync(
         _In_ IUnknown* file, 
         _In_ IUnknown* options, 
         _Out_ IAsyncOperation** operation)
@@ -105,7 +108,7 @@ public:
         return LaunchFileAsync(file, operation);
     };
 
-    STDMETHODIMP_(HRESULT) LaunchUriAsync(
+    STDMETHODIMP HRESULT LaunchUriAsync(
         _In_    IUriRuntimeClass*   uri, 
         _Out_   IAsyncOperation**   operation)
     {
@@ -113,7 +116,7 @@ public:
 	    HSTRING RawUri;
 	    HINSTANCE ShellExecuteResult;
         
-        Result = Uri->lpVtbl->get_AbsoluteUri(uri, &RawUri);
+        Result = uri->lpVtbl->get_AbsoluteUri(uri, &RawUri);
 	    if (FAILED(Result)) {
 		    return Result;
 	    }
@@ -132,15 +135,15 @@ public:
 		    return E_FAIL;
 	    }
 
-	    *operation = (IAsyncOperation *) This;
+	    *operation = nullptr;
 
 	    return S_OK;
     };
 
-    STDMETHODIMP_(HRESULT) LaunchUriWithOptionsAsync(
+    STDMETHODIMP HRESULT LaunchUriWithOptionsAsync(
         _In_    IUriRuntimeClass* uri, 
         _In_    IUnknown* options,
-        _Out_   IUriRuntimeClass** operation)
+        _Out_   IAsyncOperation** operation)
     {
         return LaunchUriAsync(uri, operation);
     };

--- a/src/Thunks/api-ms-win-core-winrt.hpp
+++ b/src/Thunks/api-ms-win-core-winrt.hpp
@@ -1,5 +1,7 @@
 ﻿#if (YY_Thunks_Target < __WindowsNT6_2)
 #include <roapi.h>
+#include <inspectable.h>
+#include <Activation.h>
 #endif
 
 #if (YY_Thunks_Target < __WindowsNT6_2) && !defined(__Comment_Lib_ole32)
@@ -155,9 +157,29 @@ namespace YY::Thunks
         if (factory)
             *factory = nullptr;
 
-        // According to the C++/WinRT fallback implementation, we should
-        // return CLASS_E_CLASSNOTAVAILABLE.
-        return CLASS_E_CLASSNOTAVAILABLE;
+        if (IsEqualIID(__uuidof(IActivationFactory), iid))
+        {
+            *factory = (IActivationFactory*)&fbridge_factory;
+        }
+        else if (IsEqualIID(__uuidof(ILauncherStatics), iid))
+        {
+            *factory = (ILauncherStatics*)&fbridge_launcherstatics;
+        }
+        else if (IsEqualIID(__uuidof(IUIViewSettings), iid))
+        {
+            *factory = (IUIViewSettings*)&fbridge_uiviewsettings;
+        }
+        else if (IsEqualIID(__uuidof(IUIViewSettingsInterop), iid))
+        {
+            *factory = (IUIViewSettingsInterop*)&fbridge_uiviewsettingsinterop;
+        }
+        else if (IsEqualIID(__uuidof(IGlobalizationPreferencesStatics), iid))
+        {
+            *factory = (IGlobalizationPreferencesStatics*)&fbridge_globalization;
+        }
+        else return E_NOINTERFACE;
+        
+        return S_OK;
     }
 #endif
 

--- a/src/Thunks/api-ms-win-core-winrt.hpp
+++ b/src/Thunks/api-ms-win-core-winrt.hpp
@@ -9,6 +9,145 @@
 #pragma comment(lib, "Ole32.lib")
 #endif
 
+MIDL_INTERFACE("277151C3-9E3E-42F6-91A4-5DFDEB232451")
+    ILauncherStatics : public IInspectable
+{
+public:
+    virtual HRESULT STDMETHODCALLTYPE TreatAsUntrusted(boolean * value) = 0;
+    virtual HRESULT STDMETHODCALLTYPE LaunchFileAsync(void* file,boolean** operation) = 0;
+    virtual HRESULT STDMETHODCALLTYPE LaunchFileWithOptionsAsync(void* file, void* options, boolean** operation) = 0;
+    virtual HRESULT STDMETHODCALLTYPE LaunchUriAsync(void* uri, boolean** operation) = 0;
+    virtual HRESULT STDMETHODCALLTYPE LaunchUriWithOptionsAsync(void* uri, void* options, boolean** operation) = 0;
+};
+
+class __declspec(uuid("{44111111-1111-1111-1111-111111111111}")) fakeLauncherStatics1 : public ILauncherStatics
+{
+public:
+    STDMETHODIMP QueryInterface(
+        _In_ REFIID riid, 
+        _Out_ void** ppv)
+    {
+        if (NULL == ppv)
+            return E_POINTER;
+        if ((IID_IUnknown == riid)
+            || (__uuidof(ILauncherStatics) == riid)
+            || (__uuidof(IInspectable) == riid) || (__uuidof(IAgileObject) == riid))
+        {
+            AddRef();
+            *ppv = (fakeShellBridge1*)(&fbridge1);
+            return S_OK;
+        }
+        return E_NOINTERFACE;
+    };
+
+    STDMETHODIMP_(ULONG) AddRef(void) 
+    { 
+        return 1; 
+    };
+    
+    STDMETHODIMP_(ULONG) Release(void) 
+    { 
+        return 1; 
+    };
+
+    STDMETHODIMP_(HRESULT) GetIids(
+        _Out_ ULONG* iidCount,
+        _Out_ IID** iids) 
+    {
+        IID *Array;
+    	ULONG Count;
+    
+        Count = 1;
+    
+    	Array = (IID *) CoTaskMemAlloc(Count * sizeof(IID));
+    	if (!Array) {
+    		return E_OUTOFMEMORY;
+    	}
+    
+    	*iidCount = Count;
+    	Array[0] = __uuidof(ILauncherStatics);
+    
+    	return S_OK;
+    };
+
+    STDMETHODIMP_(HRESULT) GetRuntimeClassName(
+        _Out_ HSTRING* className)
+    {
+        PCWSTR Name = L"Windows.System.Launcher";
+        return WindowsCreateString(Name, (ULONG) wcslen(Name), className);
+    };
+
+    STDMETHODIMP_(HRESULT) GetTrustLevel(
+        _Out_ TrustLevel* trustLevel) 
+    {
+        *trustLevel = BaseTrust;
+        return S_OK;
+    };
+
+    STDMETHODIMP_(HRESULT) TreatAsUntrusted(
+        boolean* value)
+    {
+        return 7;
+    };
+
+    STDMETHODIMP_(HRESULT) LaunchFileAsync(
+        _In_ IUnknown* file, 
+        _Out_ IAsyncOperation** operation)
+    {
+        return E_NOTIMPL;
+    };
+
+    STDMETHODIMP_(HRESULT) LaunchFileWithOptionsAsync(
+        _In_ IUnknown* file, 
+        _In_ IUnknown* options, 
+        _Out_ IAsyncOperation** operation)
+    {
+        return LaunchFileAsync(file, operation);
+    };
+
+    STDMETHODIMP_(HRESULT) LaunchUriAsync(
+        _In_    IUriRuntimeClass*   uri, 
+        _Out_   IAsyncOperation**   operation)
+    {
+        HRESULT Result;
+	    HSTRING RawUri;
+	    HINSTANCE ShellExecuteResult;
+        
+        Result = Uri->lpVtbl->get_AbsoluteUri(uri, &RawUri);
+	    if (FAILED(Result)) {
+		    return Result;
+	    }
+
+	    ShellExecuteResult = ShellExecute(
+		    NULL,
+		    L"open",
+		    WindowsGetStringRawBuffer(RawUri, NULL),
+		    NULL,
+		    NULL,
+		    SW_SHOW);
+
+	    WindowsDeleteString(RawUri);
+
+	    if (((ULONG) ShellExecuteResult) <= 32) {
+		    return E_FAIL;
+	    }
+
+	    *operation = (IAsyncOperation *) This;
+
+	    return S_OK;
+    };
+
+    STDMETHODIMP_(HRESULT) LaunchUriWithOptionsAsync(
+        _In_    IUriRuntimeClass* uri, 
+        _In_    IUnknown* options,
+        _Out_   IUriRuntimeClass** operation)
+    {
+        return LaunchUriAsync(uri, operation);
+    };
+};
+
+static fakeLauncherStatics1 fbridge_launcherstatics;
+
 namespace YY::Thunks
 {
 #if (YY_Thunks_Target < __WindowsNT6_2)
@@ -177,7 +316,10 @@ namespace YY::Thunks
         {
             *factory = (IGlobalizationPreferencesStatics*)&fbridge_globalization;
         }
-        else return E_NOINTERFACE;
+        else
+        {
+            return E_NOINTERFACE;
+        }
         
         return S_OK;
     }

--- a/src/Thunks/api-ms-win-core-winrt.hpp
+++ b/src/Thunks/api-ms-win-core-winrt.hpp
@@ -151,6 +151,82 @@ public:
 
 static fakeLauncherStatics1 fbridge_launcherstatics;
 
+class __declspec(uuid("{22111111-1111-1111-1111-111111111111}")) fakeActivateFactory1 : public IActivationFactory
+{
+public:
+    STDMETHODIMP QueryInterface(
+    _In_ REFIID riid, 
+    _Out_ void** ppv)
+    {
+        if (NULL == ppv)
+            return E_POINTER;
+        if ((IID_IUnknown == riid)
+            || (__uuidof(IActivationFactory) == riid)
+            || (__uuidof(IInspectable) == riid) || (__uuidof(IAgileObject) == riid))
+        {
+            AddRef();
+            *ppv = (IActivationFactory*)(this);
+            return S_OK;
+        }
+
+        return E_NOINTERFACE;
+    };
+
+    STDMETHODIMP_(ULONG) AddRef(void) 
+    { 
+        return 1; 
+    };
+
+    STDMETHODIMP_(ULONG) Release(void) 
+    { 
+        return 1; 
+    };
+
+    STDMETHODIMP HRESULT GetIids(
+        _Out_ ULONG* iidCount,
+        _Out_ IID** iids) 
+    {
+        IID *Array;
+	    ULONG Count;
+
+    	Count = 1;
+    
+    	Array = (IID *) CoTaskMemAlloc(Count * sizeof(IID));
+    	if (!Array) {
+    		return E_OUTOFMEMORY;
+    	}
+    	Array[0] = IID_IActivationFactory;
+        
+    	*iidCount = Count;
+        *iids = Array;
+    
+    	return S_OK;
+    };
+
+    STDMETHODIMP HRESULT GetRuntimeClassName(
+        _Out_ HSTRING* className)
+    {
+        PCWSTR Name = L"IActivationFactory";
+	    return WindowsCreateString(Name, (ULONG) wcslen(Name), ClassName);
+    };
+
+    STDMETHODIMP HRESULT GetTrustLevel(
+        _Out_ TrustLevel* trustLevel) 
+    {
+        *trustLevel = BaseTrust;
+        return S_OK;
+    };
+
+    STDMETHODIMP HRESULT ActivateInstance(
+        _Out_ IInspectable** instance)
+    {
+        *instance = (IInspectable *) this;
+        return S_OK;
+    }
+};
+
+fakeActivateFactory1 fbridge_factory;
+
 namespace YY::Thunks
 {
 #if (YY_Thunks_Target < __WindowsNT6_2)
@@ -219,11 +295,10 @@ namespace YY::Thunks
         {
             return pRoActivateInstance(activatableClassId, instance);
         }
+        
+        *instance = (IInspectable *) &fbridge_factory;
 
-        if (instance)
-            *instance = nullptr;
-
-        return E_NOTIMPL;
+        return S_OK;
     }
 #endif
 

--- a/src/Thunks/api-ms-win-core-winrt.hpp
+++ b/src/Thunks/api-ms-win-core-winrt.hpp
@@ -42,15 +42,9 @@ public:
         return E_NOINTERFACE;
     };
 
-    STDMETHODIMP_(ULONG) AddRef(void) 
-    { 
-        return 1; 
-    };
+    STDMETHODIMP_(ULONG) AddRef(void) { return 1; };
     
-    STDMETHODIMP_(ULONG) Release(void) 
-    { 
-        return 1; 
-    };
+    STDMETHODIMP_(ULONG) Release(void) { return 1; };
 
     STDMETHODIMP HRESULT GetIids(
         _Out_ ULONG* iidCount,
@@ -155,8 +149,8 @@ class __declspec(uuid("{22111111-1111-1111-1111-111111111111}")) fakeActivateFac
 {
 public:
     STDMETHODIMP QueryInterface(
-    _In_ REFIID riid, 
-    _Out_ void** ppv)
+        _In_ REFIID riid, 
+        _Out_ void** ppv)
     {
         if (NULL == ppv)
             return E_POINTER;
@@ -172,15 +166,9 @@ public:
         return E_NOINTERFACE;
     };
 
-    STDMETHODIMP_(ULONG) AddRef(void) 
-    { 
-        return 1; 
-    };
+    STDMETHODIMP_(ULONG) AddRef(void) { return 1; };
 
-    STDMETHODIMP_(ULONG) Release(void) 
-    { 
-        return 1; 
-    };
+    STDMETHODIMP_(ULONG) Release(void) { return 1; };
 
     STDMETHODIMP HRESULT GetIids(
         _Out_ ULONG* iidCount,
@@ -203,29 +191,94 @@ public:
     	return S_OK;
     };
 
-    STDMETHODIMP HRESULT GetRuntimeClassName(
-        _Out_ HSTRING* className)
-    {
+    STDMETHODIMP HRESULT GetRuntimeClassName(_Out_ HSTRING* className) {
         PCWSTR Name = L"IActivationFactory";
 	    return WindowsCreateString(Name, (ULONG) wcslen(Name), ClassName);
     };
 
-    STDMETHODIMP HRESULT GetTrustLevel(
-        _Out_ TrustLevel* trustLevel) 
-    {
-        *trustLevel = BaseTrust;
-        return S_OK;
-    };
+    STDMETHODIMP HRESULT GetTrustLevel(_Out_ TrustLevel* trustLevel) { *trustLevel = BaseTrust; return S_OK; };
 
-    STDMETHODIMP HRESULT ActivateInstance(
-        _Out_ IInspectable** instance)
-    {
-        *instance = (IInspectable *) this;
+    STDMETHODIMP HRESULT ActivateInstance(_Out_ IInspectable** instance) {
+        if (instance) *instance = nullptr;
         return S_OK;
     }
 };
 
-fakeActivateFactory1 fbridge_factory;
+static fakeActivateFactory1 fbridge_factory;
+
+MIDL_INTERFACE("c63657f6-8850-470d-88f8-455e16ea2c26")
+IUIViewSettings : public IInspectable
+{
+public:
+virtual HRESULT STDMETHODCALLTYPE get_UserInteractionMode(void* value) = 0;
+};
+
+class __declspec(uuid("{33111111-1111-1111-1111-111111111111}")) fakeUiViewSettings : public IUIViewSettings
+{
+    STDMETHODIMP QueryInterface(
+        _In_ REFIID riid, 
+        _Out_ void** ppv)
+    {
+        *ppv = nullptr;
+        if (IsEqualIID(RefIID, &IID_IUnknown) ||
+		IsEqualIID(RefIID, &IID_IAgileObject) ||
+		IsEqualIID(RefIID, &IID_IInspectable) ||
+		IsEqualIID(RefIID, &IID_IUIViewSettings)) {
+		*Interface = this;
+		return S_OK;
+        }
+
+        return E_NOINTERFACE;
+    };
+
+    STDMETHODIMP_(ULONG) AddRef(void)
+    {
+    	return 1;
+    }
+
+    STDMETHODIMP_(ULONG) Release(void)
+    {
+    	return 1;
+    }
+
+    STDMETHODIMP HRESULT GetIids(
+        _Out_ ULONG* iidCount,
+        _Out_ IID** iids) 
+    {
+        IID *Array;
+	    ULONG Count;
+
+    	Count = 1;
+    
+    	Array = (IID *) CoTaskMemAlloc(Count * sizeof(IID));
+    	if (!Array) {
+    		return E_OUTOFMEMORY;
+    	}
+    	Array[0] = IID_IActivationFactory;
+        
+    	*iidCount = Count;
+        *iids = Array;
+    
+    	return S_OK;
+    };
+
+    STDMETHODIMP HRESULT GetRuntimeClassName(_Out_ HSTRING* className) {
+        PCWSTR Name = L"Windows.UI.ViewManagement.UISettings";
+	    return WindowsCreateString(Name, (ULONG) wcslen(Name), ClassName);
+    };
+
+    STDMETHODIMP HRESULT GetTrustLevel(_Out_ TrustLevel* trustLevel) { *trustLevel = BaseTrust; return S_OK; };
+
+    STDMETHODIMP HRESULT get_UserInteractionMode(
+	    _Out_	UserInteractionMode	*InteractionMode)
+    {
+	    *InteractionMode = UserInteractionMode_Mouse;
+	    return S_OK;
+    }
+
+};
+
+static fakeUiViewSettings fbridge_uiviewsettings;
 
 namespace YY::Thunks
 {

--- a/src/Thunks/api-ms-win-core-winrt.hpp
+++ b/src/Thunks/api-ms-win-core-winrt.hpp
@@ -1,7 +1,10 @@
-﻿#if (YY_Thunks_Target < __WindowsNT6_2)
+#if (YY_Thunks_Target < __WindowsNT6_2)
 #include <roapi.h>
 #include <inspectable.h>
 #include <Activation.h>
+#include <shellapi.h>
+#include <locale.h>
+#include <combaseapi.h>
 #endif
 
 #if (YY_Thunks_Target < __WindowsNT6_2) && !defined(__Comment_Lib_ole32)
@@ -9,276 +12,523 @@
 #pragma comment(lib, "Ole32.lib")
 #endif
 
-MIDL_INTERFACE("277151C3-9E3E-42F6-91A4-5DFDEB232451")
-    ILauncherStatics : public IInspectable
+#if (YY_Thunks_Target < __WindowsNT6_2)
+#define SafeAllocEx(Heap, Flags, Type, Count) ((Type*)HeapAlloc((Heap), (Flags), sizeof(Type) * (Count)))
+#define SafeAlloc(Type, Count) SafeAllocEx(GetProcessHeap(), 0, Type, (Count))
+#define SafeFreeEx(Heap, Flags, Pointer)  do { if (Pointer) { HeapFree((Heap), (Flags), (Pointer)); (Pointer) = nullptr; } } while(0)
+#define SafeFree(Pointer) SafeFreeEx(GetProcessHeap(), 0, (Pointer))
+
+typedef enum _YY_AsyncStatus {
+    YY_AsyncStatus_Started = 0,
+    YY_AsyncStatus_Completed = 1,
+    YY_AsyncStatus_Canceled = 2,
+    YY_AsyncStatus_Error = 3
+} YY_AsyncStatus;
+
+typedef enum _YY_UserInteractionMode {
+    UserInteractionMode_Mouse,
+    UserInteractionMode_Touch
+} YY_UserInteractionMode;
+
+typedef enum _YY_DayOfWeek {
+    DayOfWeek_Sunday = 0,
+    DayOfWeek_Monday = 1,
+    DayOfWeek_Tuesday = 2,
+    DayOfWeek_Wednesday = 3,
+    DayOfWeek_Thursday = 4,
+    DayOfWeek_Friday = 5,
+    DayOfWeek_Saturday = 6,
+} YY_DayOfWeek;
+
+MIDL_INTERFACE("9E365E57-48B2-4160-956F-C7385120BBFC")
+IUriRuntimeClass : public IInspectable{
+    virtual HRESULT STDMETHODCALLTYPE get_AbsoluteUri(HSTRING * value) = 0;
+};
+
+MIDL_INTERFACE("00000036-0000-0000-C000-000000000046")
+IAsyncInfo : public IUnknown
 {
+    virtual HRESULT STDMETHODCALLTYPE get_Id(ULONG * id) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_Status(YY_AsyncStatus* asyncStatus) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_ErrorCode(HRESULT* errorCode) = 0;
+    virtual HRESULT STDMETHODCALLTYPE Cancel(void) = 0;
+    virtual HRESULT STDMETHODCALLTYPE Close(void) = 0;
+};
+
+MIDL_INTERFACE("F51F7C4E-8905-4994-8A9D-439B38694297")
+IAsyncOperationBoolean : public IAsyncInfo
+{
+    virtual HRESULT STDMETHODCALLTYPE GetResults(boolean * result) = 0;
+    virtual HRESULT STDMETHODCALLTYPE put_Completed(void* handler) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_Completed(void** handler) = 0;
+};
+
+MIDL_INTERFACE("277151C3-9E3E-42F6-91A4-5DFDEB232451")
+ILauncherStatics : public IInspectable{
 public:
     virtual HRESULT STDMETHODCALLTYPE TreatAsUntrusted(boolean * value) = 0;
-    virtual HRESULT STDMETHODCALLTYPE LaunchFileAsync(void* file,boolean** operation) = 0;
-    virtual HRESULT STDMETHODCALLTYPE LaunchFileWithOptionsAsync(void* file, void* options, boolean** operation) = 0;
-    virtual HRESULT STDMETHODCALLTYPE LaunchUriAsync(void* uri, boolean** operation) = 0;
-    virtual HRESULT STDMETHODCALLTYPE LaunchUriWithOptionsAsync(void* uri, void* options, boolean** operation) = 0;
+    virtual HRESULT STDMETHODCALLTYPE LaunchFileAsync(IUnknown* file, IAsyncOperationBoolean** operation) = 0;
+    virtual HRESULT STDMETHODCALLTYPE LaunchFileWithOptionsAsync(IUnknown* file, IUnknown* options, IAsyncOperationBoolean** operation) = 0;
+    virtual HRESULT STDMETHODCALLTYPE LaunchUriAsync(IUriRuntimeClass* uri, IAsyncOperationBoolean** operation) = 0;
+    virtual HRESULT STDMETHODCALLTYPE LaunchUriWithOptionsAsync(IUriRuntimeClass* uri, IUnknown* options, IAsyncOperationBoolean** operation) = 0;
 };
 
-class __declspec(uuid("{44111111-1111-1111-1111-111111111111}")) fakeLauncherStatics1 : public ILauncherStatics
-{
-public:
-    STDMETHODIMP QueryInterface(
-        _In_ REFIID riid, 
-        _Out_ void** ppv)
-    {
-        if (NULL == ppv)
-            return E_POINTER;
-    
-        if ((IID_IUnknown == riid)
-            || (__uuidof(ILauncherStatics) == riid)
-            || (__uuidof(IInspectable) == riid) || (__uuidof(IAgileObject) == riid))
-        {
-            AddRef();
-            *ppv = (ILauncherStatics*)(this);
-            return S_OK;
-        }
-    
-        return E_NOINTERFACE;
-    };
-
-    STDMETHODIMP_(ULONG) AddRef(void) { return 1; };
-    
-    STDMETHODIMP_(ULONG) Release(void) { return 1; };
-
-    STDMETHODIMP HRESULT GetIids(
-        _Out_ ULONG* iidCount,
-        _Out_ IID** iids) 
-    {
-        IID *Array;
-        ULONG Count = 1;
-    	Array = (IID *) CoTaskMemAlloc(Count * sizeof(IID));
-        
-    	if (!Array) {
-    		return E_OUTOFMEMORY;
-    	}
-        
-    	Array[0] = __uuidof(ILauncherStatics);
-        
-    	*iidCount = Count;
-        *iids = Array;
-    
-    	return S_OK;
-    };
-
-    STDMETHODIMP HRESULT GetRuntimeClassName(
-        _Out_ HSTRING* className)
-    {
-        PCWSTR Name = L"Windows.System.Launcher";
-        return WindowsCreateString(Name, (ULONG) wcslen(Name), className);
-    };
-
-    STDMETHODIMP HRESULT GetTrustLevel(
-        _Out_ TrustLevel* trustLevel) 
-    {
-        *trustLevel = BaseTrust;
-        return S_OK;
-    };
-
-    STDMETHODIMP HRESULT TreatAsUntrusted(
-        boolean* value)
-    {
-        *value = FALSE;
-        return S_OK;
-    };
-
-    STDMETHODIMP HRESULT LaunchFileAsync(
-        _In_ IUnknown* file, 
-        _Out_ IAsyncOperation** operation)
-    {
-        return E_NOTIMPL;
-    };
-
-    STDMETHODIMP HRESULT LaunchFileWithOptionsAsync(
-        _In_ IUnknown* file, 
-        _In_ IUnknown* options, 
-        _Out_ IAsyncOperation** operation)
-    {
-        return LaunchFileAsync(file, operation);
-    };
-
-    STDMETHODIMP HRESULT LaunchUriAsync(
-        _In_    IUriRuntimeClass*   uri, 
-        _Out_   IAsyncOperation**   operation)
-    {
-        HRESULT Result;
-	    HSTRING RawUri;
-	    HINSTANCE ShellExecuteResult;
-        
-        Result = uri->lpVtbl->get_AbsoluteUri(uri, &RawUri);
-	    if (FAILED(Result)) {
-		    return Result;
-	    }
-
-	    ShellExecuteResult = ShellExecute(
-		    NULL,
-		    L"open",
-		    WindowsGetStringRawBuffer(RawUri, NULL),
-		    NULL,
-		    NULL,
-		    SW_SHOW);
-
-	    WindowsDeleteString(RawUri);
-
-	    if (((ULONG) ShellExecuteResult) <= 32) {
-		    return E_FAIL;
-	    }
-
-	    *operation = nullptr;
-
-	    return S_OK;
-    };
-
-    STDMETHODIMP HRESULT LaunchUriWithOptionsAsync(
-        _In_    IUriRuntimeClass* uri, 
-        _In_    IUnknown* options,
-        _Out_   IAsyncOperation** operation)
-    {
-        return LaunchUriAsync(uri, operation);
-    };
-};
-
-static fakeLauncherStatics1 fbridge_launcherstatics;
-
-class __declspec(uuid("{22111111-1111-1111-1111-111111111111}")) fakeActivateFactory1 : public IActivationFactory
-{
-public:
-    STDMETHODIMP QueryInterface(
-        _In_ REFIID riid, 
-        _Out_ void** ppv)
-    {
-        if (NULL == ppv)
-            return E_POINTER;
-        if ((IID_IUnknown == riid)
-            || (__uuidof(IActivationFactory) == riid)
-            || (__uuidof(IInspectable) == riid) || (__uuidof(IAgileObject) == riid))
-        {
-            AddRef();
-            *ppv = (IActivationFactory*)(this);
-            return S_OK;
-        }
-
-        return E_NOINTERFACE;
-    };
-
-    STDMETHODIMP_(ULONG) AddRef(void) { return 1; };
-
-    STDMETHODIMP_(ULONG) Release(void) { return 1; };
-
-    STDMETHODIMP HRESULT GetIids(
-        _Out_ ULONG* iidCount,
-        _Out_ IID** iids) 
-    {
-        IID *Array;
-	    ULONG Count;
-
-    	Count = 1;
-    
-    	Array = (IID *) CoTaskMemAlloc(Count * sizeof(IID));
-    	if (!Array) {
-    		return E_OUTOFMEMORY;
-    	}
-    	Array[0] = IID_IActivationFactory;
-        
-    	*iidCount = Count;
-        *iids = Array;
-    
-    	return S_OK;
-    };
-
-    STDMETHODIMP HRESULT GetRuntimeClassName(_Out_ HSTRING* className) {
-        PCWSTR Name = L"IActivationFactory";
-	    return WindowsCreateString(Name, (ULONG) wcslen(Name), ClassName);
-    };
-
-    STDMETHODIMP HRESULT GetTrustLevel(_Out_ TrustLevel* trustLevel) { *trustLevel = BaseTrust; return S_OK; };
-
-    STDMETHODIMP HRESULT ActivateInstance(_Out_ IInspectable** instance) {
-        if (instance) *instance = nullptr;
-        return S_OK;
-    }
-};
-
-static fakeActivateFactory1 fbridge_factory;
-
-MIDL_INTERFACE("c63657f6-8850-470d-88f8-455e16ea2c26")
+MIDL_INTERFACE("C63657F6-8850-470D-88F8-455E16EA2C26")
 IUIViewSettings : public IInspectable
 {
 public:
-virtual HRESULT STDMETHODCALLTYPE get_UserInteractionMode(void* value) = 0;
+virtual HRESULT STDMETHODCALLTYPE get_UserInteractionMode(YY_UserInteractionMode * InteractionMode) = 0;
 };
 
-class __declspec(uuid("{33111111-1111-1111-1111-111111111111}")) fakeUiViewSettings : public IUIViewSettings
+MIDL_INTERFACE("3694DBF9-8F68-44BE-8FF5-195C98EDE8A6")
+IUIViewSettingsInterop : public IInspectable{
+    virtual HRESULT STDMETHODCALLTYPE GetForWindow(HWND appWindow, REFIID riid, void** ppv) = 0;
+};
+
+MIDL_INTERFACE("BBE1FA4C-B0E3-4583-BAEF-1F1B2E483E56")
+IVectorView_HSTRING : public IInspectable{
+    virtual HRESULT STDMETHODCALLTYPE get_Size(unsigned* size) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetAt(unsigned index, HSTRING* value) = 0;
+    virtual HRESULT STDMETHODCALLTYPE IndexOf(HSTRING value, unsigned* index, boolean* found) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetMany(unsigned startIndex, unsigned capacity, HSTRING* value, unsigned* actual) = 0;
+};
+
+MIDL_INTERFACE("01BF4326-ED37-4E96-B0E9-C1340D1EA158")
+IGlobalizationPreferencesStatics : public IInspectable
 {
-    STDMETHODIMP QueryInterface(
-        _In_ REFIID riid, 
-        _Out_ void** ppv)
-    {
-        *ppv = nullptr;
-        if (IsEqualIID(RefIID, &IID_IUnknown) ||
-		IsEqualIID(RefIID, &IID_IAgileObject) ||
-		IsEqualIID(RefIID, &IID_IInspectable) ||
-		IsEqualIID(RefIID, &IID_IUIViewSettings)) {
-		*Interface = this;
-		return S_OK;
+public:
+virtual HRESULT STDMETHODCALLTYPE get_Calendars(IVectorView_HSTRING * *value) = 0;
+virtual HRESULT STDMETHODCALLTYPE get_Clocks(IVectorView_HSTRING** value) = 0;
+virtual HRESULT STDMETHODCALLTYPE get_Currencies(IVectorView_HSTRING** value) = 0;
+virtual HRESULT STDMETHODCALLTYPE get_Languages(IVectorView_HSTRING** value) = 0;
+virtual HRESULT STDMETHODCALLTYPE get_HomeGeographicRegion(HSTRING* value) = 0;
+virtual HRESULT STDMETHODCALLTYPE get_WeekStartsOn(YY_DayOfWeek* value) = 0;
+};
+
+class StubAsyncOperationBoolean : public IAsyncOperationBoolean
+{
+public:
+    STDMETHODIMP QueryInterface(REFIID riid, void** ppv) override {
+        if (!ppv) return E_POINTER; *ppv = nullptr;
+        if (riid == IID_IUnknown || riid == __uuidof(IAsyncInfo) || riid == __uuidof(IAsyncOperationBoolean)) {
+            AddRef(); *ppv = static_cast<IAsyncOperationBoolean*>(this); return S_OK;
+        }
+        return E_NOINTERFACE;
+    }
+    STDMETHODIMP_(ULONG) AddRef() override { return 1; }
+    STDMETHODIMP_(ULONG) Release() override { return 1; }
+
+    STDMETHODIMP get_Id(ULONG*) override { return E_NOTIMPL; }
+    STDMETHODIMP get_Status(YY_AsyncStatus* status) override {
+        if (status) *status = YY_AsyncStatus_Completed; return S_OK;
+    }
+    STDMETHODIMP get_ErrorCode(HRESULT* error) override {
+        if (error) *error = S_OK; return S_OK;
+    }
+    STDMETHODIMP Cancel() override { return S_OK; }
+    STDMETHODIMP Close() override { return S_OK; }
+
+    STDMETHODIMP GetResults(boolean* result) override {
+        if (result) *result = TRUE; return S_OK;
+    }
+    STDMETHODIMP put_Completed(void*) override { return S_OK; }
+    STDMETHODIMP get_Completed(void**) override { return E_NOTIMPL; }
+};
+
+__declspec(selectany) static StubAsyncOperationBoolean g_StubAsyncOpBool;
+
+class fakeLauncherStatics : public ILauncherStatics
+{
+public:
+    STDMETHODIMP QueryInterface(_In_ REFIID riid, _Out_ void** ppv) override {
+        if (!ppv) return E_POINTER; *ppv = nullptr;
+        if (riid == IID_IUnknown || riid == __uuidof(ILauncherStatics) || riid == __uuidof(IInspectable) || riid == __uuidof(IAgileObject)) {
+            AddRef(); *ppv = static_cast<ILauncherStatics*>(this); return S_OK;
+        }
+        return E_NOINTERFACE;
+    }
+    STDMETHODIMP_(ULONG) AddRef() override { return 1; }
+    STDMETHODIMP_(ULONG) Release() override { return 1; }
+    STDMETHODIMP GetIids(_Out_ ULONG* iidCount, _Out_ IID** iids) override {
+        if (!iidCount || !iids) return E_POINTER;
+        *iids = static_cast<IID*>(CoTaskMemAlloc(sizeof(IID)));
+        if (!*iids) return E_OUTOFMEMORY;
+        (*iids)[0] = __uuidof(ILauncherStatics);
+        *iidCount = 1;
+        return S_OK;
+    }
+    STDMETHODIMP GetRuntimeClassName(_Out_ HSTRING* className) override {
+        return WindowsCreateString(L"Windows.System.Launcher", 23, className);
+    }
+    STDMETHODIMP GetTrustLevel(_Out_ TrustLevel* trustLevel) override { *trustLevel = BaseTrust; return S_OK; }
+    STDMETHODIMP TreatAsUntrusted(boolean* value) override { *value = FALSE; return S_OK; }
+    STDMETHODIMP LaunchFileAsync(IUnknown*, IAsyncOperationBoolean**) override { return E_NOTIMPL; }
+    STDMETHODIMP LaunchFileWithOptionsAsync(IUnknown*, IUnknown*, IAsyncOperationBoolean**) override { return E_NOTIMPL; }
+    STDMETHODIMP LaunchUriWithOptionsAsync(IUriRuntimeClass* uri, IUnknown*, IAsyncOperationBoolean** operation) override {
+        if (!uri || !operation) return E_POINTER;
+        return LaunchUriAsync(uri, operation);
+    }
+    STDMETHODIMP LaunchUriAsync(_In_ IUriRuntimeClass* uri, _Out_ IAsyncOperationBoolean** operation) override {
+        if (!uri || !operation) return E_POINTER;
+        *operation = nullptr;
+
+        HSTRING hstrUri = nullptr;
+        HRESULT hr = uri->get_AbsoluteUri(&hstrUri);
+        if (FAILED(hr)) return hr;
+
+        bool launched = false;
+        PCWSTR uriStr = WindowsGetStringRawBuffer(hstrUri, nullptr);
+        if (uriStr) {
+            INT_PTR res = reinterpret_cast<INT_PTR>(ShellExecuteW(nullptr, L"open", uriStr, nullptr, nullptr, SW_SHOWNORMAL));
+            launched = (res > 32);
+        }
+        WindowsDeleteString(hstrUri);
+
+        if (!launched) return E_FAIL;
+
+        *operation = &g_StubAsyncOpBool;
+        return S_OK;
+    }
+};
+
+__declspec(selectany) static fakeLauncherStatics f_launcherstatics;
+
+class fakeActivationFactory : public IActivationFactory
+{
+public:
+    STDMETHODIMP QueryInterface(_In_ REFIID riid, _Out_ void** ppv) override {
+        if (!ppv) return E_POINTER; *ppv = nullptr;
+        if ((IID_IUnknown == riid) || (__uuidof(IActivationFactory) == riid) || (__uuidof(IInspectable) == riid) || (__uuidof(IAgileObject) == riid)) {
+            AddRef(); *ppv = static_cast<IActivationFactory*>(this); return S_OK;
+        }
+        return E_NOINTERFACE;
+    }
+    STDMETHODIMP_(ULONG) AddRef() override { return 1; }
+    STDMETHODIMP_(ULONG) Release() override { return 1; }
+    STDMETHODIMP GetIids(_Out_ ULONG* iidCount, _Out_ IID** iids) override {
+        if (!iidCount || !iids) return E_POINTER;
+        *iids = static_cast<IID*>(CoTaskMemAlloc(sizeof(IID)));
+        if (!*iids) return E_OUTOFMEMORY;
+        (*iids)[0] = __uuidof(IActivationFactory);
+        *iidCount = 1;
+        return S_OK;
+    }
+    STDMETHODIMP GetRuntimeClassName(_Out_ HSTRING* className) override {
+        PCWSTR Name = L"IActivationFactory";
+        return WindowsCreateString(Name, (ULONG)wcslen(Name), className);
+    }
+    STDMETHODIMP GetTrustLevel(_Out_ TrustLevel* trustLevel) override { *trustLevel = BaseTrust; return S_OK; }
+    STDMETHODIMP ActivateInstance(_Out_ IInspectable** instance) override { if (instance) *instance = nullptr; return E_NOTIMPL; }
+};
+
+__declspec(selectany) static fakeActivationFactory f_factory;
+
+class fakeUiViewSettings : public IUIViewSettings
+{
+    STDMETHODIMP QueryInterface(_In_ REFIID riid, _Out_ void** ppv) override {
+        if (!ppv) return E_POINTER; *ppv = nullptr;
+        if ((riid == IID_IUnknown) || (riid == IID_IAgileObject) || (riid == IID_IInspectable) || (riid == __uuidof(IUIViewSettings))) {
+            AddRef(); *ppv = static_cast<IUIViewSettings*>(this); return S_OK;
+        }
+        return E_NOINTERFACE;
+    }
+    STDMETHODIMP_(ULONG) AddRef() override { return 1; }
+    STDMETHODIMP_(ULONG) Release() override { return 1; }
+    STDMETHODIMP GetIids(_Out_ ULONG* iidCount, _Out_ IID** iids) override {
+        if (!iidCount || !iids) return E_POINTER;
+        *iids = static_cast<IID*>(CoTaskMemAlloc(sizeof(IID)));
+        if (!*iids) return E_OUTOFMEMORY;
+        (*iids)[0] = __uuidof(IUIViewSettings);
+        *iidCount = 1;
+        return S_OK;
+    }
+    STDMETHODIMP GetRuntimeClassName(_Out_ HSTRING* className) override {
+        return WindowsCreateString(L"Windows.UI.ViewManagement.UIViewSettings", 36, className);
+    }
+    STDMETHODIMP GetTrustLevel(_Out_ TrustLevel* trustLevel) override { *trustLevel = BaseTrust; return S_OK; };
+    STDMETHODIMP get_UserInteractionMode(_Out_	YY_UserInteractionMode* InteractionMode) override {
+        if (!InteractionMode) return E_POINTER;
+        *InteractionMode = UserInteractionMode_Mouse;
+        return S_OK;
+    }
+};
+
+__declspec(selectany) static fakeUiViewSettings f_viewsettings;
+
+class fakeUiViewSettingsInterop : public IUIViewSettingsInterop {
+public:
+    STDMETHODIMP QueryInterface(_In_ REFIID riid, _Out_ void** ppv) override {
+        if (!ppv) return E_POINTER; *ppv = nullptr;
+        if (riid == IID_IUnknown || riid == IID_IAgileObject ||
+            riid == IID_IInspectable || riid == __uuidof(IUIViewSettingsInterop)) {
+            AddRef(); *ppv = static_cast<IUIViewSettingsInterop*>(this); return S_OK;
+        }
+        return E_NOINTERFACE;
+    }
+    STDMETHODIMP_(ULONG) AddRef() override { return 1; }
+    STDMETHODIMP_(ULONG) Release() override { return 1; }
+    STDMETHODIMP GetIids(_Out_ ULONG* iidCount, _Out_ IID** iids) override {
+        if (!iidCount || !iids) return E_POINTER;
+        *iids = static_cast<IID*>(CoTaskMemAlloc(sizeof(IID)));
+        if (!*iids) return E_OUTOFMEMORY;
+        (*iids)[0] = __uuidof(IUIViewSettingsInterop);
+        *iidCount = 1;
+        return S_OK;
+    }
+    STDMETHODIMP GetRuntimeClassName(_Out_ HSTRING* className) override {
+        return WindowsCreateString(L"Windows.UI.ViewManagement.UIViewSettings", 36, className);
+    }
+    STDMETHODIMP GetTrustLevel(_Out_ TrustLevel* trustLevel) override { *trustLevel = BaseTrust; return S_OK; };
+
+    STDMETHODIMP GetForWindow(HWND appWindow, REFIID riid, void** ppv) override {
+        if (!ppv) return E_POINTER;
+        *ppv = NULL;
+
+        if (!(riid == __uuidof(IUIViewSettings))) {
+            return E_NOINTERFACE;
         }
 
-        return E_NOINTERFACE;
-    };
-
-    STDMETHODIMP_(ULONG) AddRef(void)
-    {
-    	return 1;
+        *ppv = &f_viewsettings;
+        return S_OK;
     }
-
-    STDMETHODIMP_(ULONG) Release(void)
-    {
-    	return 1;
-    }
-
-    STDMETHODIMP HRESULT GetIids(
-        _Out_ ULONG* iidCount,
-        _Out_ IID** iids) 
-    {
-        IID *Array;
-	    ULONG Count;
-
-    	Count = 1;
-    
-    	Array = (IID *) CoTaskMemAlloc(Count * sizeof(IID));
-    	if (!Array) {
-    		return E_OUTOFMEMORY;
-    	}
-    	Array[0] = IID_IActivationFactory;
-        
-    	*iidCount = Count;
-        *iids = Array;
-    
-    	return S_OK;
-    };
-
-    STDMETHODIMP HRESULT GetRuntimeClassName(_Out_ HSTRING* className) {
-        PCWSTR Name = L"Windows.UI.ViewManagement.UISettings";
-	    return WindowsCreateString(Name, (ULONG) wcslen(Name), ClassName);
-    };
-
-    STDMETHODIMP HRESULT GetTrustLevel(_Out_ TrustLevel* trustLevel) { *trustLevel = BaseTrust; return S_OK; };
-
-    STDMETHODIMP HRESULT get_UserInteractionMode(
-	    _Out_	UserInteractionMode	*InteractionMode)
-    {
-	    *InteractionMode = UserInteractionMode_Mouse;
-	    return S_OK;
-    }
-
 };
 
-static fakeUiViewSettings fbridge_uiviewsettings;
+__declspec(selectany) static fakeUiViewSettingsInterop f_viewsettingsinterop;
+
+class StubVectorView_HSTRING : public IVectorView_HSTRING {
+public:
+    LONG        RefCount;
+    ULONG       NumberOfHstrings;
+    HSTRING* HstringArray;
+
+    StubVectorView_HSTRING(PCWSTR* strings, ULONG count)
+        : RefCount(1), NumberOfHstrings(0), HstringArray(nullptr)
+    {
+        if (count == 0 || !strings) return;
+
+        HstringArray = SafeAlloc(HSTRING, count);
+        if (!HstringArray) return;
+
+        for (ULONG i = 0; i < count; ++i) {
+            HRESULT hr = WindowsCreateString(strings[i], (ULONG)wcslen(strings[i]), &HstringArray[i]);
+            if (FAILED(hr)) {
+                while (NumberOfHstrings > 0) {
+                    WindowsDeleteString(HstringArray[--NumberOfHstrings]);
+                }
+                SafeFree(HstringArray);
+                HstringArray = nullptr;
+                return;
+            }
+            ++NumberOfHstrings;
+        }
+    }
+
+    ~StubVectorView_HSTRING() {
+        while (NumberOfHstrings > 0) {
+            WindowsDeleteString(HstringArray[--NumberOfHstrings]);
+        }
+        SafeFree(HstringArray);
+    }
+
+    STDMETHODIMP QueryInterface(REFIID riid, void** ppv) override {
+        if (!ppv) return E_POINTER; *ppv = nullptr;
+        if (riid == IID_IUnknown || riid == IID_IInspectable || riid == __uuidof(IVectorView_HSTRING)) {
+            AddRef(); *ppv = static_cast<IVectorView_HSTRING*>(this); return S_OK;
+        }
+        return E_NOINTERFACE;
+    }
+    STDMETHODIMP_(ULONG) AddRef() override { return _InterlockedIncrement(&RefCount); }
+    STDMETHODIMP_(ULONG) Release() override {
+        LONG newRef = _InterlockedDecrement(&RefCount);
+        if (newRef == 0) {
+            this->~StubVectorView_HSTRING();
+            HeapFree(GetProcessHeap(), 0, this);
+        }
+        return newRef;
+    }
+    STDMETHODIMP GetIids(_Out_ ULONG* iidCount, _Out_ IID** iids) override {
+        if (!iidCount || !iids) return E_POINTER;
+        *iids = static_cast<IID*>(CoTaskMemAlloc(sizeof(IID)));
+        if (!*iids) return E_OUTOFMEMORY;
+        (*iids)[0] = __uuidof(IVectorView_HSTRING);
+        *iidCount = 1;
+        return S_OK;
+    }
+    STDMETHODIMP GetRuntimeClassName(HSTRING* className) override {
+        PCWSTR Name = L"Windows.Foundation.Collections.IVector";
+        return WindowsCreateString(Name, (ULONG)wcslen(Name), className);
+    }
+    STDMETHODIMP GetTrustLevel(_Out_ TrustLevel* trustLevel) override { *trustLevel = BaseTrust; return S_OK; };
+
+    STDMETHODIMP get_Size(unsigned* size) override {
+        if (!size) return E_POINTER;
+        *size = NumberOfHstrings;
+        return S_OK;
+    }
+    STDMETHODIMP GetAt(unsigned index, HSTRING* value) override {
+        if (!value) return E_POINTER;
+        *value = nullptr;
+        if (!HstringArray || index >= NumberOfHstrings) return E_BOUNDS;
+        return WindowsDuplicateString(HstringArray[index], value);
+    }
+    STDMETHODIMP IndexOf(HSTRING String, unsigned* IndexOut, boolean* WasFound) override {
+        if (!IndexOut || !WasFound) return E_POINTER;
+        *IndexOut = 0; *WasFound = FALSE;
+
+        if (!String || !HstringArray) return S_OK;
+
+        for (ULONG i = 0; i < NumberOfHstrings; ++i) {
+            INT cmp;
+            if (SUCCEEDED(WindowsCompareStringOrdinal(String, HstringArray[i], &cmp)) && cmp == 0) {
+                *IndexOut = i; *WasFound = TRUE; return S_OK;
+            }
+        }
+        return S_OK;
+    }
+    STDMETHODIMP GetMany(unsigned StartIndex, unsigned NumberOfItems, HSTRING* Items, unsigned* NumberOfItemsOut) override {
+        if (!Items || !NumberOfItemsOut) return E_POINTER;
+        *NumberOfItemsOut = 0;
+
+        if (!HstringArray || StartIndex >= NumberOfHstrings) return S_OK;
+
+        RtlZeroMemory(Items, NumberOfItems * sizeof(*Items));
+
+        for (ULONG i = StartIndex; i < NumberOfHstrings && *NumberOfItemsOut < NumberOfItems; ++i) {
+            HRESULT hr = WindowsDuplicateString(HstringArray[i], &Items[*NumberOfItemsOut]);
+            if (FAILED(hr)) {
+                while (*NumberOfItemsOut > 0) {
+                    WindowsDeleteString(Items[--(*NumberOfItemsOut)]);
+                }
+                return hr;
+            }
+            ++(*NumberOfItemsOut);
+        }
+        return S_OK;
+    }
+};
+
+inline IVectorView_HSTRING* CreateStubVectorView(PCWSTR* strings, ULONG count) {
+    void* mem = SafeAlloc(BYTE, sizeof(StubVectorView_HSTRING));
+    if (!mem) return nullptr;
+
+    auto* obj = static_cast<StubVectorView_HSTRING*>(mem);
+
+    obj->RefCount = 1;
+    obj->NumberOfHstrings = 0;
+    obj->HstringArray = SafeAlloc(HSTRING, count);
+
+    if (!obj->HstringArray) {
+        SafeFree(obj);
+        return nullptr;
+    }
+
+    for (ULONG i = 0; i < count; ++i) {
+        HRESULT hr = WindowsCreateString(strings[i], (ULONG)wcslen(strings[i]), &obj->HstringArray[i]);
+        if (FAILED(hr)) {
+            while (obj->NumberOfHstrings > 0) WindowsDeleteString(obj->HstringArray[--obj->NumberOfHstrings]);
+            SafeFree(obj->HstringArray);
+            SafeFree(obj);
+            return nullptr;
+        }
+        ++obj->NumberOfHstrings;
+    }
+    return static_cast<IVectorView_HSTRING*>(obj);
+}
+
+class fakeGlobalizationPreferencesStatics : public IGlobalizationPreferencesStatics {
+public:
+    STDMETHODIMP QueryInterface(_In_ REFIID riid, _Out_ void** ppv) override {
+        if (!ppv) return E_POINTER; *ppv = nullptr;
+        if (riid == IID_IUnknown || riid == IID_IAgileObject ||
+            riid == IID_IInspectable || riid == __uuidof(IGlobalizationPreferencesStatics)) {
+            AddRef(); *ppv = static_cast<IGlobalizationPreferencesStatics*>(this); return S_OK;
+        }
+        return E_NOINTERFACE;
+    }
+    STDMETHODIMP_(ULONG) AddRef() override { return 1; }
+    STDMETHODIMP_(ULONG) Release() override { return 1; }
+
+    STDMETHODIMP GetIids(_Out_ ULONG* iidCount, _Out_ IID** iids) override {
+        if (!iidCount || !iids) return E_POINTER;
+        *iids = static_cast<IID*>(CoTaskMemAlloc(sizeof(IID)));
+        if (!*iids) return E_OUTOFMEMORY;
+        (*iids)[0] = __uuidof(IGlobalizationPreferencesStatics);
+        *iidCount = 1;
+        return S_OK;
+    }
+    STDMETHODIMP GetRuntimeClassName(_Out_ HSTRING* className) override {
+        return WindowsCreateString(L"Windows.System.UserProfile.GlobalizationPreferences", 45, className);
+    }
+    STDMETHODIMP GetTrustLevel(_Out_ TrustLevel* trustLevel) override {
+        *trustLevel = BaseTrust; return S_OK;
+    }
+
+    // Коллекции не критичны для Qt6 → возвращаем E_NOTIMPL
+    STDMETHODIMP get_Calendars(IVectorView_HSTRING** value) override { return E_NOTIMPL; }
+    STDMETHODIMP get_Currencies(IVectorView_HSTRING**) override { return E_NOTIMPL; }
+    STDMETHODIMP get_Clocks(IVectorView_HSTRING** value) override { return E_NOTIMPL; }
+
+    STDMETHODIMP get_HomeGeographicRegion(HSTRING* value) override {
+        if (!value) return E_POINTER;
+        ULONG ResultCch;
+        WCHAR CountryName[8];
+
+        ResultCch = GetLocaleInfoEx(
+            LOCALE_NAME_USER_DEFAULT,
+            LOCALE_ICOUNTRY,
+            CountryName,
+            ARRAYSIZE(CountryName));
+
+        if (ResultCch == 0) {
+            return HRESULT_FROM_WIN32(GetLastError());
+        }
+
+        return WindowsCreateString(CountryName, (ULONG)wcslen(CountryName), value);
+    }
+
+    STDMETHODIMP get_Languages(IVectorView_HSTRING** VectorView) override {
+        if (!VectorView) return E_POINTER;
+        *VectorView = nullptr;
+
+        WCHAR LocaleName[LOCALE_NAME_MAX_LENGTH];
+        int cch = GetUserDefaultLocaleName(LocaleName, LOCALE_NAME_MAX_LENGTH);
+        if (cch == 0) return HRESULT_FROM_WIN32(GetLastError());
+
+        PCWSTR langs[] = { LocaleName };
+        IVectorView_HSTRING* view = CreateStubVectorView(langs, 1);
+
+        *VectorView = view;
+        return view ? S_OK : E_OUTOFMEMORY;
+    }
+
+    STDMETHODIMP get_WeekStartsOn(YY_DayOfWeek* value) override {
+        ULONG ResultCch;
+        ULONG WeekStartsOn;
+
+        if (!value) return E_POINTER;
+
+        ResultCch = GetLocaleInfoEx(
+            LOCALE_NAME_USER_DEFAULT,
+            LOCALE_RETURN_NUMBER | LOCALE_IFIRSTDAYOFWEEK,
+            (PWSTR)&WeekStartsOn,
+            2);
+        if (ResultCch == 0) {
+            return HRESULT_FROM_WIN32(GetLastError());
+        }
+
+        if (WeekStartsOn == 6) {
+            *value = DayOfWeek_Sunday;
+        }
+        else {
+            *value = (YY_DayOfWeek)(WeekStartsOn + 1);
+        }
+
+        return S_OK;
+    }
+};
+
+__declspec(selectany) static fakeGlobalizationPreferencesStatics f_globalization;
+#endif // YY_Thunks_Target < __WindowsNT10_0
 
 namespace YY::Thunks
 {
@@ -349,7 +599,7 @@ namespace YY::Thunks
             return pRoActivateInstance(activatableClassId, instance);
         }
         
-        *instance = (IInspectable *) &fbridge_factory;
+        *instance = (IInspectable*)&f_factory;
 
         return S_OK;
     }
@@ -429,29 +679,29 @@ namespace YY::Thunks
 
         if (IsEqualIID(__uuidof(IActivationFactory), iid))
         {
-            *factory = (IActivationFactory*)&fbridge_factory;
+            *factory = (IActivationFactory*)&f_factory;
         }
         else if (IsEqualIID(__uuidof(ILauncherStatics), iid))
         {
-            *factory = (ILauncherStatics*)&fbridge_launcherstatics;
+            *factory = (ILauncherStatics*)&f_launcherstatics;
         }
         else if (IsEqualIID(__uuidof(IUIViewSettings), iid))
         {
-            *factory = (IUIViewSettings*)&fbridge_uiviewsettings;
+            *factory = (IUIViewSettings*)&f_viewsettings;
         }
         else if (IsEqualIID(__uuidof(IUIViewSettingsInterop), iid))
         {
-            *factory = (IUIViewSettingsInterop*)&fbridge_uiviewsettingsinterop;
+            *factory = (IUIViewSettingsInterop*)&f_viewsettingsinterop;
         }
         else if (IsEqualIID(__uuidof(IGlobalizationPreferencesStatics), iid))
         {
-            *factory = (IGlobalizationPreferencesStatics*)&fbridge_globalization;
+            *factory = (IGlobalizationPreferencesStatics*)&f_globalization;
         }
         else
         {
             return E_NOINTERFACE;
         }
-        
+
         return S_OK;
     }
 #endif

--- a/src/Thunks/api-ms-win-core-winrt.hpp
+++ b/src/Thunks/api-ms-win-core-winrt.hpp
@@ -1,10 +1,12 @@
 #if (YY_Thunks_Target < __WindowsNT6_2)
 #include <roapi.h>
+#include <activation.h>
 #include <inspectable.h>
-#include <Activation.h>
-#include <shellapi.h>
-#include <locale.h>
-#include <combaseapi.h>
+#endif
+
+#if (YY_Thunks_Target < __WindowsNT10_10240)
+#include <windows.ui.viewmanagement.h>
+#include <UIViewSettingsInterop.h>
 #endif
 
 #if (YY_Thunks_Target < __WindowsNT6_2) && !defined(__Comment_Lib_ole32)
@@ -12,526 +14,202 @@
 #pragma comment(lib, "Ole32.lib")
 #endif
 
-#if (YY_Thunks_Target < __WindowsNT6_2) && !defined(YY_WINRT_QT6_STUBS)
-#define YY_WINRT_QT6_STUBS
-
-#define SafeAllocEx(Heap, Flags, Type, Count) ((Type*)HeapAlloc((Heap), (Flags), sizeof(Type) * (Count)))
-#define SafeAlloc(Type, Count) SafeAllocEx(GetProcessHeap(), 0, Type, (Count))
-#define SafeFreeEx(Heap, Flags, Pointer)  do { if (Pointer) { HeapFree((Heap), (Flags), (Pointer)); (Pointer) = nullptr; } } while(0)
-#define SafeFree(Pointer) SafeFreeEx(GetProcessHeap(), 0, (Pointer))
-
-#ifndef boolean
-typedef unsigned char boolean;
-#endif
-
-typedef enum _YY_AsyncStatus {
-    YY_AsyncStatus_Started = 0,
-    YY_AsyncStatus_Completed = 1,
-    YY_AsyncStatus_Canceled = 2,
-    YY_AsyncStatus_Error = 3
-} YY_AsyncStatus;
-
-typedef enum _YY_UserInteractionMode {
-    UserInteractionMode_Mouse,
-    UserInteractionMode_Touch
-} YY_UserInteractionMode;
-
-typedef enum _YY_DayOfWeek {
-    DayOfWeek_Sunday = 0,
-    DayOfWeek_Monday = 1,
-    DayOfWeek_Tuesday = 2,
-    DayOfWeek_Wednesday = 3,
-    DayOfWeek_Thursday = 4,
-    DayOfWeek_Friday = 5,
-    DayOfWeek_Saturday = 6,
-} YY_DayOfWeek;
-
-MIDL_INTERFACE("9E365E57-48B2-4160-956F-C7385120BBFC")
-IUriRuntimeClass : public IInspectable{
-    virtual HRESULT STDMETHODCALLTYPE get_AbsoluteUri(HSTRING * value) = 0;
-};
-
-MIDL_INTERFACE("00000036-0000-0000-C000-000000000046")
-IAsyncInfo : public IUnknown
+#if defined(YY_Thunks_Implemented)
+namespace YY::Thunks::Fallback
 {
-    virtual HRESULT STDMETHODCALLTYPE get_Id(ULONG * id) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_Status(YY_AsyncStatus* asyncStatus) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_ErrorCode(HRESULT* errorCode) = 0;
-    virtual HRESULT STDMETHODCALLTYPE Cancel(void) = 0;
-    virtual HRESULT STDMETHODCALLTYPE Close(void) = 0;
-};
-
-MIDL_INTERFACE("F51F7C4E-8905-4994-8A9D-439B38694297")
-IAsyncOperationBoolean : public IAsyncInfo
-{
-    virtual HRESULT STDMETHODCALLTYPE GetResults(boolean * result) = 0;
-    virtual HRESULT STDMETHODCALLTYPE put_Completed(void* handler) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_Completed(void** handler) = 0;
-};
-
-MIDL_INTERFACE("277151C3-9E3E-42F6-91A4-5DFDEB232451")
-ILauncherStatics : public IInspectable{
-public:
-    virtual HRESULT STDMETHODCALLTYPE TreatAsUntrusted(boolean * value) = 0;
-    virtual HRESULT STDMETHODCALLTYPE LaunchFileAsync(IUnknown* file, IAsyncOperationBoolean** operation) = 0;
-    virtual HRESULT STDMETHODCALLTYPE LaunchFileWithOptionsAsync(IUnknown* file, IUnknown* options, IAsyncOperationBoolean** operation) = 0;
-    virtual HRESULT STDMETHODCALLTYPE LaunchUriAsync(IUriRuntimeClass* uri, IAsyncOperationBoolean** operation) = 0;
-    virtual HRESULT STDMETHODCALLTYPE LaunchUriWithOptionsAsync(IUriRuntimeClass* uri, IUnknown* options, IAsyncOperationBoolean** operation) = 0;
-};
-
-MIDL_INTERFACE("C63657F6-8850-470D-88F8-455E16EA2C26")
-IUIViewSettings : public IInspectable
-{
-public:
-virtual HRESULT STDMETHODCALLTYPE get_UserInteractionMode(YY_UserInteractionMode * InteractionMode) = 0;
-};
-
-MIDL_INTERFACE("3694DBF9-8F68-44BE-8FF5-195C98EDE8A6")
-IUIViewSettingsInterop : public IInspectable{
-    virtual HRESULT STDMETHODCALLTYPE GetForWindow(HWND appWindow, REFIID riid, void** ppv) = 0;
-};
-
-MIDL_INTERFACE("BBE1FA4C-B0E3-4583-BAEF-1F1B2E483E56")
-IVectorView_HSTRING : public IInspectable{
-    virtual HRESULT STDMETHODCALLTYPE get_Size(unsigned* size) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetAt(unsigned index, HSTRING* value) = 0;
-    virtual HRESULT STDMETHODCALLTYPE IndexOf(HSTRING value, unsigned* index, boolean* found) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetMany(unsigned startIndex, unsigned capacity, HSTRING* value, unsigned* actual) = 0;
-};
-
-MIDL_INTERFACE("01BF4326-ED37-4E96-B0E9-C1340D1EA158")
-IGlobalizationPreferencesStatics : public IInspectable
-{
-public:
-virtual HRESULT STDMETHODCALLTYPE get_Calendars(IVectorView_HSTRING * *value) = 0;
-virtual HRESULT STDMETHODCALLTYPE get_Clocks(IVectorView_HSTRING** value) = 0;
-virtual HRESULT STDMETHODCALLTYPE get_Currencies(IVectorView_HSTRING** value) = 0;
-virtual HRESULT STDMETHODCALLTYPE get_Languages(IVectorView_HSTRING** value) = 0;
-virtual HRESULT STDMETHODCALLTYPE get_HomeGeographicRegion(HSTRING* value) = 0;
-virtual HRESULT STDMETHODCALLTYPE get_WeekStartsOn(YY_DayOfWeek* value) = 0;
-};
-
-class StubAsyncOperationBoolean : public IAsyncOperationBoolean
-{
-public:
-    STDMETHODIMP QueryInterface(REFIID riid, void** ppv) override {
-        if (!ppv) return E_POINTER; *ppv = nullptr;
-        if (IsEqualIID(riid, IID_IUnknown) || IsEqualIID(riid, __uuidof(IAsyncInfo)) || IsEqualIID(riid, __uuidof(IAsyncOperationBoolean))) {
-            AddRef(); *ppv = static_cast<IAsyncOperationBoolean*>(this); return S_OK;
-        }
-        return E_NOINTERFACE;
-    }
-    STDMETHODIMP_(ULONG) AddRef() override { return 1; }
-    STDMETHODIMP_(ULONG) Release() override { return 1; }
-
-    STDMETHODIMP get_Id(ULONG*) override { return E_NOTIMPL; }
-    STDMETHODIMP get_Status(YY_AsyncStatus* status) override {
-        if (status) *status = YY_AsyncStatus_Completed; return S_OK;
-    }
-    STDMETHODIMP get_ErrorCode(HRESULT* error) override {
-        if (error) *error = S_OK; return S_OK;
-    }
-    STDMETHODIMP Cancel() override { return S_OK; }
-    STDMETHODIMP Close() override { return S_OK; }
-
-    STDMETHODIMP GetResults(boolean* result) override {
-        if (result) *result = TRUE; return S_OK;
-    }
-    STDMETHODIMP put_Completed(void*) override { return S_OK; }
-    STDMETHODIMP get_Completed(void**) override { return E_NOTIMPL; }
-};
-
-static StubAsyncOperationBoolean g_StubAsyncOpBool;
-
-class fakeLauncherStatics : public ILauncherStatics
-{
-public:
-    STDMETHODIMP QueryInterface(_In_ REFIID riid, _Out_ void** ppv) override {
-        if (!ppv) return E_POINTER; *ppv = nullptr;
-        if (IsEqualIID(riid, IID_IUnknown) || IsEqualIID(riid, __uuidof(ILauncherStatics)) || IsEqualIID(riid, __uuidof(IInspectable)) || IsEqualIID(riid, __uuidof(IAgileObject))) {
-            AddRef(); *ppv = static_cast<ILauncherStatics*>(this); return S_OK;
-        }
-        return E_NOINTERFACE;
-    }
-    STDMETHODIMP_(ULONG) AddRef() override { return 1; }
-    STDMETHODIMP_(ULONG) Release() override { return 1; }
-    STDMETHODIMP GetIids(_Out_ ULONG* iidCount, _Out_ IID** iids) override {
-        if (!iidCount || !iids) return E_POINTER;
-        *iids = static_cast<IID*>(CoTaskMemAlloc(sizeof(IID)));
-        if (!*iids) return E_OUTOFMEMORY;
-        (*iids)[0] = __uuidof(ILauncherStatics);
-        *iidCount = 1;
-        return S_OK;
-    }
-    STDMETHODIMP GetRuntimeClassName(_Out_ HSTRING* className) override {
-        return WindowsCreateString(L"Windows.System.Launcher", 23, className);
-    }
-    STDMETHODIMP GetTrustLevel(_Out_ TrustLevel* trustLevel) override { *trustLevel = BaseTrust; return S_OK; }
-    STDMETHODIMP TreatAsUntrusted(boolean* value) override { *value = FALSE; return S_OK; }
-    STDMETHODIMP LaunchFileAsync(IUnknown*, IAsyncOperationBoolean**) override { return E_NOTIMPL; }
-    STDMETHODIMP LaunchFileWithOptionsAsync(IUnknown*, IUnknown*, IAsyncOperationBoolean**) override { return E_NOTIMPL; }
-    STDMETHODIMP LaunchUriWithOptionsAsync(IUriRuntimeClass* uri, IUnknown*, IAsyncOperationBoolean** operation) override {
-        if (!uri || !operation) return E_POINTER;
-        return LaunchUriAsync(uri, operation);
-    }
-    STDMETHODIMP LaunchUriAsync(_In_ IUriRuntimeClass* uri, _Out_ IAsyncOperationBoolean** operation) override {
-        if (!uri || !operation) return E_POINTER;
-        *operation = nullptr;
-
-        HSTRING hstrUri = nullptr;
-        HRESULT hr = uri->get_AbsoluteUri(&hstrUri);
-        if (FAILED(hr)) return hr;
-
-        bool launched = false;
-        PCWSTR uriStr = WindowsGetStringRawBuffer(hstrUri, nullptr);
-        if (uriStr) {
-            INT_PTR res = reinterpret_cast<INT_PTR>(ShellExecuteW(nullptr, L"open", uriStr, nullptr, nullptr, SW_SHOWNORMAL));
-            launched = (res > 32);
-        }
-        WindowsDeleteString(hstrUri);
-
-        if (!launched) return E_FAIL;
-
-        *operation = &g_StubAsyncOpBool;
-        return S_OK;
-    }
-};
-
-static fakeLauncherStatics f_launcherstatics;
-
-class fakeActivationFactory : public IActivationFactory
-{
-public:
-    STDMETHODIMP QueryInterface(_In_ REFIID riid, _Out_ void** ppv) override {
-        if (!ppv) return E_POINTER; *ppv = nullptr;
-        if (IsEqualIID(IID_IUnknown, riid) || IsEqualIID(__uuidof(IActivationFactory), riid) || IsEqualIID(__uuidof(IInspectable), riid) || IsEqualIID(__uuidof(IAgileObject), riid)) {
-            AddRef(); *ppv = static_cast<IActivationFactory*>(this); return S_OK;
-        }
-        return E_NOINTERFACE;
-    }
-    STDMETHODIMP_(ULONG) AddRef() override { return 1; }
-    STDMETHODIMP_(ULONG) Release() override { return 1; }
-    STDMETHODIMP GetIids(_Out_ ULONG* iidCount, _Out_ IID** iids) override {
-        if (!iidCount || !iids) return E_POINTER;
-        *iids = static_cast<IID*>(CoTaskMemAlloc(sizeof(IID)));
-        if (!*iids) return E_OUTOFMEMORY;
-        (*iids)[0] = __uuidof(IActivationFactory);
-        *iidCount = 1;
-        return S_OK;
-    }
-    STDMETHODIMP GetRuntimeClassName(_Out_ HSTRING* className) override {
-        PCWSTR Name = L"IActivationFactory";
-        return WindowsCreateString(Name, (ULONG)wcslen(Name), className);
-    }
-    STDMETHODIMP GetTrustLevel(_Out_ TrustLevel* trustLevel) override { *trustLevel = BaseTrust; return S_OK; }
-    STDMETHODIMP ActivateInstance(_Out_ IInspectable** instance) override { if (instance) *instance = nullptr; return E_NOTIMPL; }
-};
-
-static fakeActivationFactory f_factory;
-
-class fakeUiViewSettings : public IUIViewSettings
-{
-    STDMETHODIMP QueryInterface(_In_ REFIID riid, _Out_ void** ppv) override {
-        if (!ppv) return E_POINTER; *ppv = nullptr;
-        if (IsEqualIID(riid, IID_IUnknown) || IsEqualIID(riid, IID_IAgileObject) || IsEqualIID(riid, IID_IInspectable) || IsEqualIID(riid, __uuidof(IUIViewSettings))) {
-            AddRef(); *ppv = static_cast<IUIViewSettings*>(this); return S_OK;
-        }
-        return E_NOINTERFACE;
-    }
-    STDMETHODIMP_(ULONG) AddRef() override { return 1; }
-    STDMETHODIMP_(ULONG) Release() override { return 1; }
-    STDMETHODIMP GetIids(_Out_ ULONG* iidCount, _Out_ IID** iids) override {
-        if (!iidCount || !iids) return E_POINTER;
-        *iids = static_cast<IID*>(CoTaskMemAlloc(sizeof(IID)));
-        if (!*iids) return E_OUTOFMEMORY;
-        (*iids)[0] = __uuidof(IUIViewSettings);
-        *iidCount = 1;
-        return S_OK;
-    }
-    STDMETHODIMP GetRuntimeClassName(_Out_ HSTRING* className) override {
-        return WindowsCreateString(L"Windows.UI.ViewManagement.UIViewSettings", 36, className);
-    }
-    STDMETHODIMP GetTrustLevel(_Out_ TrustLevel* trustLevel) override { *trustLevel = BaseTrust; return S_OK; };
-    STDMETHODIMP get_UserInteractionMode(_Out_	YY_UserInteractionMode* InteractionMode) override {
-        if (!InteractionMode) return E_POINTER;
-        *InteractionMode = UserInteractionMode_Mouse;
-        return S_OK;
-    }
-};
-
-static fakeUiViewSettings f_viewsettings;
-
-class fakeUiViewSettingsInterop : public IUIViewSettingsInterop {
-public:
-    STDMETHODIMP QueryInterface(_In_ REFIID riid, _Out_ void** ppv) override {
-        if (!ppv) return E_POINTER; *ppv = nullptr;
-        if (IsEqualIID(riid, IID_IUnknown) || IsEqualIID(riid, IID_IAgileObject) ||
-            IsEqualIID(riid, IID_IInspectable) || IsEqualIID(riid, __uuidof(IUIViewSettingsInterop))) {
-            AddRef(); *ppv = static_cast<IUIViewSettingsInterop*>(this); return S_OK;
-        }
-        return E_NOINTERFACE;
-    }
-    STDMETHODIMP_(ULONG) AddRef() override { return 1; }
-    STDMETHODIMP_(ULONG) Release() override { return 1; }
-    STDMETHODIMP GetIids(_Out_ ULONG* iidCount, _Out_ IID** iids) override {
-        if (!iidCount || !iids) return E_POINTER;
-        *iids = static_cast<IID*>(CoTaskMemAlloc(sizeof(IID)));
-        if (!*iids) return E_OUTOFMEMORY;
-        (*iids)[0] = __uuidof(IUIViewSettingsInterop);
-        *iidCount = 1;
-        return S_OK;
-    }
-    STDMETHODIMP GetRuntimeClassName(_Out_ HSTRING* className) override {
-        return WindowsCreateString(L"Windows.UI.ViewManagement.UIViewSettings", 36, className);
-    }
-    STDMETHODIMP GetTrustLevel(_Out_ TrustLevel* trustLevel) override { *trustLevel = BaseTrust; return S_OK; };
-
-    STDMETHODIMP GetForWindow(HWND appWindow, REFIID riid, void** ppv) override {
-        if (!ppv) return E_POINTER;
-        *ppv = NULL;
-
-        if (!IsEqualIID(riid, __uuidof(IUIViewSettings))) { return E_NOINTERFACE; }
-
-        *ppv = &f_viewsettings;
-        return S_OK;
-    }
-};
-
-static fakeUiViewSettingsInterop f_viewsettingsinterop;
-
-class StubVectorView_HSTRING : public IVectorView_HSTRING {
-public:
-    LONG        RefCount;
-    ULONG       NumberOfHstrings;
-    HSTRING* HstringArray;
-
-    StubVectorView_HSTRING(PCWSTR* strings, ULONG count)
-        : RefCount(1), NumberOfHstrings(0), HstringArray(nullptr)
+    namespace
     {
-        if (count == 0 || !strings) return;
+#if (YY_Thunks_Target < __WindowsNT10_10240)
+        class CUIViewSettings : public ABI::Windows::UI::ViewManagement::IUIViewSettings
+        {
+        public:
+            ////////////////////////////////////////////////////////
+            // IUnknown
+            HRESULT STDMETHODCALLTYPE QueryInterface(
+                _In_ REFIID riid,
+                _COM_Outptr_ void __RPC_FAR* __RPC_FAR* ppvObject) override
+            {
+                if (!ppvObject)
+                    return E_POINTER;
 
-        HstringArray = SafeAlloc(HSTRING, count);
-        if (!HstringArray) return;
-
-        for (ULONG i = 0; i < count; ++i) {
-            HRESULT hr = WindowsCreateString(strings[i], (ULONG)wcslen(strings[i]), &HstringArray[i]);
-            if (FAILED(hr)) {
-                while (NumberOfHstrings > 0) {
-                    WindowsDeleteString(HstringArray[--NumberOfHstrings]);
+                *ppvObject = nullptr;
+                if (IsEqualGUID(riid, __uuidof(IUnknown))
+                    || IsEqualGUID(riid, __uuidof(IAgileObject))
+                    || IsEqualGUID(riid, __uuidof(IInspectable))
+                    || IsEqualGUID(riid, __uuidof(IUIViewSettings)))
+                {
+                    AddRef();
+                    *ppvObject = this;
+                    return S_OK;
                 }
-                SafeFree(HstringArray);
-                HstringArray = nullptr;
-                return;
-            }
-            ++NumberOfHstrings;
-        }
-    }
-
-    ~StubVectorView_HSTRING() {
-        while (NumberOfHstrings > 0) {
-            WindowsDeleteString(HstringArray[--NumberOfHstrings]);
-        }
-        SafeFree(HstringArray);
-    }
-
-    STDMETHODIMP QueryInterface(REFIID riid, void** ppv) override {
-        if (!ppv) return E_POINTER; *ppv = nullptr;
-        if (IsEqualIID(riid, IID_IUnknown) || IsEqualIID(riid, IID_IInspectable) || IsEqualIID(riid, __uuidof(IVectorView_HSTRING))) {
-            AddRef(); *ppv = static_cast<IVectorView_HSTRING*>(this); return S_OK;
-        }
-        return E_NOINTERFACE;
-    }
-    STDMETHODIMP_(ULONG) AddRef() override { return _InterlockedIncrement(&RefCount); }
-    STDMETHODIMP_(ULONG) Release() override {
-        LONG newRef = _InterlockedDecrement(&RefCount);
-        if (newRef == 0) {
-            this->~StubVectorView_HSTRING();
-            HeapFree(GetProcessHeap(), 0, this);
-        }
-        return newRef;
-    }
-    STDMETHODIMP GetIids(_Out_ ULONG* iidCount, _Out_ IID** iids) override {
-        if (!iidCount || !iids) return E_POINTER;
-        *iids = static_cast<IID*>(CoTaskMemAlloc(sizeof(IID)));
-        if (!*iids) return E_OUTOFMEMORY;
-        (*iids)[0] = __uuidof(IVectorView_HSTRING);
-        *iidCount = 1;
-        return S_OK;
-    }
-    STDMETHODIMP GetRuntimeClassName(HSTRING* className) override {
-        PCWSTR Name = L"Windows.Foundation.Collections.IVectorView";
-        return WindowsCreateString(Name, (ULONG)wcslen(Name), className);
-    }
-    STDMETHODIMP GetTrustLevel(_Out_ TrustLevel* trustLevel) override { *trustLevel = BaseTrust; return S_OK; };
-
-    STDMETHODIMP get_Size(unsigned* size) override {
-        if (!size) return E_POINTER;
-        *size = NumberOfHstrings;
-        return S_OK;
-    }
-    STDMETHODIMP GetAt(unsigned index, HSTRING* value) override {
-        if (!value) return E_POINTER;
-        *value = nullptr;
-        if (!HstringArray || index >= NumberOfHstrings) return E_BOUNDS;
-        return WindowsDuplicateString(HstringArray[index], value);
-    }
-    STDMETHODIMP IndexOf(HSTRING String, unsigned* IndexOut, boolean* WasFound) override {
-        if (!IndexOut || !WasFound) return E_POINTER;
-        *IndexOut = 0; *WasFound = FALSE;
-
-        if (!String || !HstringArray) return S_OK;
-
-        for (ULONG i = 0; i < NumberOfHstrings; ++i) {
-            INT cmp;
-            if (SUCCEEDED(WindowsCompareStringOrdinal(String, HstringArray[i], &cmp)) && cmp == 0) {
-                *IndexOut = i; *WasFound = TRUE; return S_OK;
-            }
-        }
-        return S_OK;
-    }
-    STDMETHODIMP GetMany(unsigned StartIndex, unsigned NumberOfItems, HSTRING* Items, unsigned* NumberOfItemsOut) override {
-        if (!Items || !NumberOfItemsOut) return E_POINTER;
-        *NumberOfItemsOut = 0;
-
-        if (!HstringArray || StartIndex >= NumberOfHstrings) return S_OK;
-
-        RtlZeroMemory(Items, NumberOfItems * sizeof(*Items));
-
-        for (ULONG i = StartIndex; i < NumberOfHstrings && *NumberOfItemsOut < NumberOfItems; ++i) {
-            HRESULT hr = WindowsDuplicateString(HstringArray[i], &Items[*NumberOfItemsOut]);
-            if (FAILED(hr)) {
-                while (*NumberOfItemsOut > 0) {
-                    WindowsDeleteString(Items[--(*NumberOfItemsOut)]);
+                else
+                {
+                    return E_NOINTERFACE;
                 }
-                return hr;
             }
-            ++(*NumberOfItemsOut);
-        }
-        return S_OK;
+
+            ULONG STDMETHODCALLTYPE AddRef(void) override
+            {
+                return 1;
+            }
+
+            ULONG STDMETHODCALLTYPE Release(void) override
+            {
+                return 1;
+            }
+
+            /////////////////////////////////////////////////////////
+            // IInspectable
+            HRESULT STDMETHODCALLTYPE GetIids(
+                _Out_ ULONG* iidCount, 
+                _Out_ IID** iids) override 
+            {
+                if (!iidCount || !iids) 
+                    return E_POINTER;
+
+                *iids = static_cast<IID*>(CoTaskMemAlloc(sizeof(IID)));
+
+                if (!*iids) 
+                    return E_OUTOFMEMORY;
+
+                (*iids)[0] = __uuidof(IUIViewSettings);
+                *iidCount = 1;
+
+                return S_OK;
+            }
+
+            HRESULT STDMETHODCALLTYPE GetRuntimeClassName(
+                _Out_ HSTRING* className) override 
+            {
+                if (!className)
+                    return E_POINTER;
+                return WindowsCreateString(L"Windows.UI.ViewManagement.UIViewSettings", 36, className);
+            }
+
+            HRESULT STDMETHODCALLTYPE GetTrustLevel(
+                _Out_ TrustLevel* trustLevel) override 
+            { 
+                if (!trustLevel)
+                    return E_POINTER;
+                *trustLevel = BaseTrust; 
+                return S_OK; 
+            }
+
+            /////////////////////////////////////////////////////////
+            // IUIViewSettings
+            HRESULT STDMETHODCALLTYPE get_UserInteractionMode(
+                _Out_ ABI::Windows::UI::ViewManagement::UserInteractionMode* InteractionMode) override 
+            {
+                if (!InteractionMode) 
+                    return E_POINTER;
+                *InteractionMode = ABI::Windows::UI::ViewManagement::UserInteractionMode_Mouse;
+                return S_OK;
+            }
+        };
+
+        static CUIViewSettings g_UIViewSettings;
+
+        class CUIViewSettingsInterop : public IUIViewSettingsInterop
+        {
+        public:
+            ////////////////////////////////////////////////////////
+            // IUnknown
+            HRESULT STDMETHODCALLTYPE QueryInterface(
+                _In_ REFIID riid,
+                _COM_Outptr_ void __RPC_FAR* __RPC_FAR* ppvObject) override
+            {
+                if (!ppvObject)
+                    return E_POINTER;
+
+                *ppvObject = nullptr;
+                if (IsEqualGUID(riid, __uuidof(IUnknown))
+                    || IsEqualGUID(riid, __uuidof(IAgileObject))
+                    || IsEqualGUID(riid, __uuidof(IInspectable))
+                    || IsEqualGUID(riid, __uuidof(IUIViewSettingsInterop)))
+                {
+                    AddRef();
+                    *ppvObject = this;
+                    return S_OK;
+                }
+                else
+                {
+                    return E_NOINTERFACE;
+                }
+            }
+
+            ULONG STDMETHODCALLTYPE AddRef(void) override
+            {
+                return 1;
+            }
+
+            ULONG STDMETHODCALLTYPE Release(void) override
+            {
+                return 1;
+            }
+
+            /////////////////////////////////////////////////////////
+            // IInspectable
+            HRESULT STDMETHODCALLTYPE GetIids(
+                _Out_ ULONG* iidCount,
+                _Out_ IID** iids) override
+            {
+                if (!iidCount || !iids)
+                    return E_POINTER;
+
+                *iids = static_cast<IID*>(CoTaskMemAlloc(sizeof(IID)));
+
+                if (!*iids)
+                    return E_OUTOFMEMORY;
+
+                (*iids)[0] = __uuidof(IUIViewSettingsInterop);
+                *iidCount = 1;
+
+                return S_OK;
+            }
+
+            HRESULT STDMETHODCALLTYPE GetRuntimeClassName(
+                _Out_ HSTRING* className) override
+            {
+                if (!className)
+                    return E_POINTER;
+                return WindowsCreateString(L"Windows.UI.ViewManagement.UIViewSettings", 36, className);
+            }
+
+            HRESULT STDMETHODCALLTYPE GetTrustLevel(
+                _Out_ TrustLevel* trustLevel) override
+            {
+                if (!trustLevel)
+                    return E_POINTER;
+                *trustLevel = BaseTrust;
+                return S_OK;
+            }
+
+            /////////////////////////////////////////////////////////
+            // IUIViewSettingsInterop
+            HRESULT STDMETHODCALLTYPE GetForWindow(
+                _In_ HWND appWindow, 
+                _In_ REFIID riid, 
+                _Out_ void** ppv) override 
+            {
+                if (!ppv) 
+                    return E_POINTER;
+                *ppv = NULL;
+
+                if (!IsEqualIID(riid, __uuidof(ABI::Windows::UI::ViewManagement::IUIViewSettings)))
+                { 
+                    return E_NOINTERFACE; 
+                }
+
+                *ppv = &g_UIViewSettings;
+                return S_OK;
+            }
+        };
+
+        static CUIViewSettingsInterop g_UIViewSettingsInterop;
+#endif // (YY_Thunks_Target < __WindowsNT10_10240)
     }
-};
-
-inline IVectorView_HSTRING* CreateStubVectorView(PCWSTR* strings, ULONG count) {
-    void* mem = SafeAlloc(BYTE, sizeof(StubVectorView_HSTRING));
-    if (!mem) return nullptr;
-
-    auto* obj = static_cast<StubVectorView_HSTRING*>(mem);
-
-    obj->RefCount = 1;
-    obj->NumberOfHstrings = 0;
-    obj->HstringArray = SafeAlloc(HSTRING, count);
-
-    if (!obj->HstringArray) {
-        SafeFree(obj);
-        return nullptr;
-    }
-
-    for (ULONG i = 0; i < count; ++i) {
-        HRESULT hr = WindowsCreateString(strings[i], (ULONG)wcslen(strings[i]), &obj->HstringArray[i]);
-        if (FAILED(hr)) {
-            while (obj->NumberOfHstrings > 0) WindowsDeleteString(obj->HstringArray[--obj->NumberOfHstrings]);
-            SafeFree(obj->HstringArray);
-            SafeFree(obj);
-            return nullptr;
-        }
-        ++obj->NumberOfHstrings;
-    }
-    return static_cast<IVectorView_HSTRING*>(obj);
 }
-
-class fakeGlobalizationPreferencesStatics : public IGlobalizationPreferencesStatics {
-public:
-    STDMETHODIMP QueryInterface(_In_ REFIID riid, _Out_ void** ppv) override {
-        if (!ppv) return E_POINTER; *ppv = nullptr;
-        if (IsEqualIID(riid, IID_IUnknown) || IsEqualIID(riid, IID_IAgileObject) ||
-            IsEqualIID(riid, IID_IInspectable) || IsEqualIID(riid, __uuidof(IGlobalizationPreferencesStatics))) {
-            AddRef(); *ppv = static_cast<IGlobalizationPreferencesStatics*>(this); return S_OK;
-        }
-        return E_NOINTERFACE;
-    }
-    STDMETHODIMP_(ULONG) AddRef() override { return 1; }
-    STDMETHODIMP_(ULONG) Release() override { return 1; }
-
-    STDMETHODIMP GetIids(_Out_ ULONG* iidCount, _Out_ IID** iids) override {
-        if (!iidCount || !iids) return E_POINTER;
-        *iids = static_cast<IID*>(CoTaskMemAlloc(sizeof(IID)));
-        if (!*iids) return E_OUTOFMEMORY;
-        (*iids)[0] = __uuidof(IGlobalizationPreferencesStatics);
-        *iidCount = 1;
-        return S_OK;
-    }
-    STDMETHODIMP GetRuntimeClassName(_Out_ HSTRING* className) override {
-        return WindowsCreateString(L"Windows.System.UserProfile.GlobalizationPreferences", 45, className);
-    }
-    STDMETHODIMP GetTrustLevel(_Out_ TrustLevel* trustLevel) override {
-        *trustLevel = BaseTrust; return S_OK;
-    }
-
-    STDMETHODIMP get_Calendars(IVectorView_HSTRING** value) override { return E_NOTIMPL; }
-    STDMETHODIMP get_Currencies(IVectorView_HSTRING**) override { return E_NOTIMPL; }
-    STDMETHODIMP get_Clocks(IVectorView_HSTRING** value) override { return E_NOTIMPL; }
-
-    STDMETHODIMP get_HomeGeographicRegion(HSTRING* value) override {
-        if (!value) return E_POINTER;
-        ULONG ResultCch;
-        WCHAR CountryName[8];
-
-        ResultCch = GetLocaleInfoEx(
-            LOCALE_NAME_USER_DEFAULT,
-            LOCALE_ICOUNTRY,
-            CountryName,
-            ARRAYSIZE(CountryName));
-
-        if (ResultCch == 0) {
-            return HRESULT_FROM_WIN32(GetLastError());
-        }
-
-        return WindowsCreateString(CountryName, (ULONG)wcslen(CountryName), value);
-    }
-
-    STDMETHODIMP get_Languages(IVectorView_HSTRING** VectorView) override {
-        if (!VectorView) return E_POINTER;
-        *VectorView = nullptr;
-
-        WCHAR LocaleName[LOCALE_NAME_MAX_LENGTH];
-        int cch = GetUserDefaultLocaleName(LocaleName, LOCALE_NAME_MAX_LENGTH);
-        if (cch == 0) return HRESULT_FROM_WIN32(GetLastError());
-
-        PCWSTR langs[] = { LocaleName };
-        IVectorView_HSTRING* view = CreateStubVectorView(langs, 1);
-
-        *VectorView = view;
-        return view ? S_OK : E_OUTOFMEMORY;
-    }
-
-    STDMETHODIMP get_WeekStartsOn(YY_DayOfWeek* value) override {
-        ULONG ResultCch;
-        ULONG WeekStartsOn;
-
-        if (!value) return E_POINTER;
-
-        ResultCch = GetLocaleInfoEx(
-            LOCALE_NAME_USER_DEFAULT,
-            LOCALE_RETURN_NUMBER | LOCALE_IFIRSTDAYOFWEEK,
-            (PWSTR)&WeekStartsOn,
-            2);
-        if (ResultCch == 0) {
-            return HRESULT_FROM_WIN32(GetLastError());
-        }
-
-        if (WeekStartsOn == 6) {
-            *value = DayOfWeek_Sunday;
-        }
-        else {
-            *value = (YY_DayOfWeek)(WeekStartsOn + 1);
-        }
-
-        return S_OK;
-    }
-};
-
-static fakeGlobalizationPreferencesStatics f_globalization;
-#endif // YY_WINRT_QT6_STUBS, YY_Thunks_Target < __WindowsNT6_2
+#endif // (YY_Thunks_Implemented)
 
 namespace YY::Thunks
 {
@@ -601,10 +279,11 @@ namespace YY::Thunks
         {
             return pRoActivateInstance(activatableClassId, instance);
         }
-        
-        *instance = (IInspectable*)&f_factory;
 
-        return S_OK;
+        if (instance)
+            *instance = nullptr;
+
+        return E_NOTIMPL;
     }
 #endif
 
@@ -672,40 +351,28 @@ namespace YY::Thunks
         _COM_Outptr_ void** factory
         )
     {
+        UNREFERENCED_PARAMETER(activatableClassId);
+
+        if (factory)
+            *factory = nullptr;
+
+        if (IsEqualIID(iid, __uuidof(ABI::Windows::UI::ViewManagement::IUIViewSettings)))
+        {
+            return Fallback::g_UIViewSettings.QueryInterface(iid, factory);
+        }
+        else if (IsEqualIID(iid, __uuidof(IUIViewSettingsInterop)))
+        {
+            return Fallback::g_UIViewSettingsInterop.QueryInterface(iid, factory);
+        }
+
         if (auto const pRoGetActivationFactory = try_get_RoGetActivationFactory())
         {
             return pRoGetActivationFactory(activatableClassId, iid, factory);
         }
 
-        if (factory)
-            *factory = nullptr;
-
-        if (IsEqualIID(__uuidof(IActivationFactory), iid))
-        {
-            *factory = (IActivationFactory*)&f_factory;
-        }
-        else if (IsEqualIID(__uuidof(ILauncherStatics), iid))
-        {
-            *factory = (ILauncherStatics*)&f_launcherstatics;
-        }
-        else if (IsEqualIID(__uuidof(IUIViewSettings), iid))
-        {
-            *factory = (IUIViewSettings*)&f_viewsettings;
-        }
-        else if (IsEqualIID(__uuidof(IUIViewSettingsInterop), iid))
-        {
-            *factory = (IUIViewSettingsInterop*)&f_viewsettingsinterop;
-        }
-        else if (IsEqualIID(__uuidof(IGlobalizationPreferencesStatics), iid))
-        {
-            *factory = (IGlobalizationPreferencesStatics*)&f_globalization;
-        }
-        else
-        {
-            return E_NOINTERFACE;
-        }
-
-        return S_OK;
+        // According to the C++/WinRT fallback implementation, we should
+        // return CLASS_E_CLASSNOTAVAILABLE.
+        return CLASS_E_CLASSNOTAVAILABLE;
     }
 #endif
 

--- a/src/Thunks/api-ms-win-core-winrt.hpp
+++ b/src/Thunks/api-ms-win-core-winrt.hpp
@@ -12,11 +12,17 @@
 #pragma comment(lib, "Ole32.lib")
 #endif
 
-#if (YY_Thunks_Target < __WindowsNT6_2)
+#if (YY_Thunks_Target < __WindowsNT6_2) && !defined(YY_WINRT_QT6_STUBS)
+#define YY_WINRT_QT6_STUBS
+
 #define SafeAllocEx(Heap, Flags, Type, Count) ((Type*)HeapAlloc((Heap), (Flags), sizeof(Type) * (Count)))
 #define SafeAlloc(Type, Count) SafeAllocEx(GetProcessHeap(), 0, Type, (Count))
 #define SafeFreeEx(Heap, Flags, Pointer)  do { if (Pointer) { HeapFree((Heap), (Flags), (Pointer)); (Pointer) = nullptr; } } while(0)
 #define SafeFree(Pointer) SafeFreeEx(GetProcessHeap(), 0, (Pointer))
+
+#ifndef boolean
+typedef unsigned char boolean;
+#endif
 
 typedef enum _YY_AsyncStatus {
     YY_AsyncStatus_Started = 0,
@@ -110,7 +116,7 @@ class StubAsyncOperationBoolean : public IAsyncOperationBoolean
 public:
     STDMETHODIMP QueryInterface(REFIID riid, void** ppv) override {
         if (!ppv) return E_POINTER; *ppv = nullptr;
-        if (riid == IID_IUnknown || riid == __uuidof(IAsyncInfo) || riid == __uuidof(IAsyncOperationBoolean)) {
+        if (IsEqualIID(riid, IID_IUnknown) || IsEqualIID(riid, __uuidof(IAsyncInfo)) || IsEqualIID(riid, __uuidof(IAsyncOperationBoolean))) {
             AddRef(); *ppv = static_cast<IAsyncOperationBoolean*>(this); return S_OK;
         }
         return E_NOINTERFACE;
@@ -135,14 +141,14 @@ public:
     STDMETHODIMP get_Completed(void**) override { return E_NOTIMPL; }
 };
 
-__declspec(selectany) static StubAsyncOperationBoolean g_StubAsyncOpBool;
+static StubAsyncOperationBoolean g_StubAsyncOpBool;
 
 class fakeLauncherStatics : public ILauncherStatics
 {
 public:
     STDMETHODIMP QueryInterface(_In_ REFIID riid, _Out_ void** ppv) override {
         if (!ppv) return E_POINTER; *ppv = nullptr;
-        if (riid == IID_IUnknown || riid == __uuidof(ILauncherStatics) || riid == __uuidof(IInspectable) || riid == __uuidof(IAgileObject)) {
+        if (IsEqualIID(riid, IID_IUnknown) || IsEqualIID(riid, __uuidof(ILauncherStatics)) || IsEqualIID(riid, __uuidof(IInspectable)) || IsEqualIID(riid, __uuidof(IAgileObject))) {
             AddRef(); *ppv = static_cast<ILauncherStatics*>(this); return S_OK;
         }
         return E_NOINTERFACE;
@@ -191,14 +197,14 @@ public:
     }
 };
 
-__declspec(selectany) static fakeLauncherStatics f_launcherstatics;
+static fakeLauncherStatics f_launcherstatics;
 
 class fakeActivationFactory : public IActivationFactory
 {
 public:
     STDMETHODIMP QueryInterface(_In_ REFIID riid, _Out_ void** ppv) override {
         if (!ppv) return E_POINTER; *ppv = nullptr;
-        if ((IID_IUnknown == riid) || (__uuidof(IActivationFactory) == riid) || (__uuidof(IInspectable) == riid) || (__uuidof(IAgileObject) == riid)) {
+        if (IsEqualIID(IID_IUnknown, riid) || IsEqualIID(__uuidof(IActivationFactory), riid) || IsEqualIID(__uuidof(IInspectable), riid) || IsEqualIID(__uuidof(IAgileObject), riid)) {
             AddRef(); *ppv = static_cast<IActivationFactory*>(this); return S_OK;
         }
         return E_NOINTERFACE;
@@ -221,13 +227,13 @@ public:
     STDMETHODIMP ActivateInstance(_Out_ IInspectable** instance) override { if (instance) *instance = nullptr; return E_NOTIMPL; }
 };
 
-__declspec(selectany) static fakeActivationFactory f_factory;
+static fakeActivationFactory f_factory;
 
 class fakeUiViewSettings : public IUIViewSettings
 {
     STDMETHODIMP QueryInterface(_In_ REFIID riid, _Out_ void** ppv) override {
         if (!ppv) return E_POINTER; *ppv = nullptr;
-        if ((riid == IID_IUnknown) || (riid == IID_IAgileObject) || (riid == IID_IInspectable) || (riid == __uuidof(IUIViewSettings))) {
+        if (IsEqualIID(riid, IID_IUnknown) || IsEqualIID(riid, IID_IAgileObject) || IsEqualIID(riid, IID_IInspectable) || IsEqualIID(riid, __uuidof(IUIViewSettings))) {
             AddRef(); *ppv = static_cast<IUIViewSettings*>(this); return S_OK;
         }
         return E_NOINTERFACE;
@@ -253,14 +259,14 @@ class fakeUiViewSettings : public IUIViewSettings
     }
 };
 
-__declspec(selectany) static fakeUiViewSettings f_viewsettings;
+static fakeUiViewSettings f_viewsettings;
 
 class fakeUiViewSettingsInterop : public IUIViewSettingsInterop {
 public:
     STDMETHODIMP QueryInterface(_In_ REFIID riid, _Out_ void** ppv) override {
         if (!ppv) return E_POINTER; *ppv = nullptr;
-        if (riid == IID_IUnknown || riid == IID_IAgileObject ||
-            riid == IID_IInspectable || riid == __uuidof(IUIViewSettingsInterop)) {
+        if (IsEqualIID(riid, IID_IUnknown) || IsEqualIID(riid, IID_IAgileObject) ||
+            IsEqualIID(riid, IID_IInspectable) || IsEqualIID(riid, __uuidof(IUIViewSettingsInterop))) {
             AddRef(); *ppv = static_cast<IUIViewSettingsInterop*>(this); return S_OK;
         }
         return E_NOINTERFACE;
@@ -284,16 +290,14 @@ public:
         if (!ppv) return E_POINTER;
         *ppv = NULL;
 
-        if (!(riid == __uuidof(IUIViewSettings))) {
-            return E_NOINTERFACE;
-        }
+        if (!IsEqualIID(riid, __uuidof(IUIViewSettings))) { return E_NOINTERFACE; }
 
         *ppv = &f_viewsettings;
         return S_OK;
     }
 };
 
-__declspec(selectany) static fakeUiViewSettingsInterop f_viewsettingsinterop;
+static fakeUiViewSettingsInterop f_viewsettingsinterop;
 
 class StubVectorView_HSTRING : public IVectorView_HSTRING {
 public:
@@ -332,7 +336,7 @@ public:
 
     STDMETHODIMP QueryInterface(REFIID riid, void** ppv) override {
         if (!ppv) return E_POINTER; *ppv = nullptr;
-        if (riid == IID_IUnknown || riid == IID_IInspectable || riid == __uuidof(IVectorView_HSTRING)) {
+        if (IsEqualIID(riid, IID_IUnknown) || IsEqualIID(riid, IID_IInspectable) || IsEqualIID(riid, __uuidof(IVectorView_HSTRING))) {
             AddRef(); *ppv = static_cast<IVectorView_HSTRING*>(this); return S_OK;
         }
         return E_NOINTERFACE;
@@ -355,7 +359,7 @@ public:
         return S_OK;
     }
     STDMETHODIMP GetRuntimeClassName(HSTRING* className) override {
-        PCWSTR Name = L"Windows.Foundation.Collections.IVector";
+        PCWSTR Name = L"Windows.Foundation.Collections.IVectorView";
         return WindowsCreateString(Name, (ULONG)wcslen(Name), className);
     }
     STDMETHODIMP GetTrustLevel(_Out_ TrustLevel* trustLevel) override { *trustLevel = BaseTrust; return S_OK; };
@@ -439,8 +443,8 @@ class fakeGlobalizationPreferencesStatics : public IGlobalizationPreferencesStat
 public:
     STDMETHODIMP QueryInterface(_In_ REFIID riid, _Out_ void** ppv) override {
         if (!ppv) return E_POINTER; *ppv = nullptr;
-        if (riid == IID_IUnknown || riid == IID_IAgileObject ||
-            riid == IID_IInspectable || riid == __uuidof(IGlobalizationPreferencesStatics)) {
+        if (IsEqualIID(riid, IID_IUnknown) || IsEqualIID(riid, IID_IAgileObject) ||
+            IsEqualIID(riid, IID_IInspectable) || IsEqualIID(riid, __uuidof(IGlobalizationPreferencesStatics))) {
             AddRef(); *ppv = static_cast<IGlobalizationPreferencesStatics*>(this); return S_OK;
         }
         return E_NOINTERFACE;
@@ -463,7 +467,6 @@ public:
         *trustLevel = BaseTrust; return S_OK;
     }
 
-    // Коллекции не критичны для Qt6 → возвращаем E_NOTIMPL
     STDMETHODIMP get_Calendars(IVectorView_HSTRING** value) override { return E_NOTIMPL; }
     STDMETHODIMP get_Currencies(IVectorView_HSTRING**) override { return E_NOTIMPL; }
     STDMETHODIMP get_Clocks(IVectorView_HSTRING** value) override { return E_NOTIMPL; }
@@ -527,8 +530,8 @@ public:
     }
 };
 
-__declspec(selectany) static fakeGlobalizationPreferencesStatics f_globalization;
-#endif // YY_Thunks_Target < __WindowsNT10_0
+static fakeGlobalizationPreferencesStatics f_globalization;
+#endif // YY_WINRT_QT6_STUBS, YY_Thunks_Target < __WindowsNT6_2
 
 namespace YY::Thunks
 {


### PR DESCRIPTION
For Qt6 to work correctly, the RoGetActivationFactory needs to work correctly, so its logic has been changed so that it returns pointers to interface factories.
Other interfaces will be needed in the future, but these should be enough for basic Qt6 operation.